### PR TITLE
Use outputs of check_secrets step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -78,7 +78,7 @@ jobs:
           SECRET: "${{ secrets.NPM_TOKEN }}"
 
       - name: Publish wasm
-        if: env.FULL_RELEASE == 'true' && steps.check_secrets.HAS_SECRET
+        if: env.FULL_RELEASE == 'true' && steps.check_secrets.outputs.HAS_SECRET
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ${{ github.workspace }}/wasm/pkg


### PR DESCRIPTION
This looks more correct, I think.  It seems that the GITHUB_OUTPUT data is available in a step's .output member.