### PR TITLE
Handle empty atom as nil

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -656,6 +656,14 @@ pub fn generate_expr_code(
                             l.clone(),
                             Rc::new(SExp::Integer(l.clone(), bi_one())),
                         ))
+                    } else if atom.is_empty() {
+                        // Ensure that we handle empty atoms as nils.
+                        generate_expr_code(
+                            context,
+                            opts,
+                            compiler,
+                            Rc::new(BodyForm::Value(SExp::Nil(l.clone()))),
+                        )
                     } else {
                         // This is as a variable access, given that we've got
                         // a Value bodyform containing an Atom, so if a defun

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -242,7 +242,7 @@ fn at_capture_inline_3() {
             "run".to_string(),
             "(mod () (defun-inline F (@ pt (X Y)) pt) (F (+ 117 1) (+ 98 1)))".to_string()
         ))
-            .trim(),
+        .trim(),
         "(q 118 99)"
     );
 }

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -242,7 +242,7 @@ fn at_capture_inline_3() {
             "run".to_string(),
             "(mod () (defun-inline F (@ pt (X Y)) pt) (F (+ 117 1) (+ 98 1)))".to_string()
         ))
-        .trim(),
+            .trim(),
         "(q 118 99)"
     );
 }

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -2306,7 +2306,6 @@ fn test_rename_in_compileform_simple() {
     assert_eq!(renamed_helperform.to_string(), desired_outcome);
 }
 
-
 #[test]
 fn test_handle_explicit_empty_atom() {
     let filename = "*empty-atom-test*";
@@ -2316,31 +2315,29 @@ fn test_handle_explicit_empty_atom() {
         strict: true,
     });
 
-    let atom = |s: &str| {
-        Rc::new(SExp::Atom(srcloc.clone(), s.as_bytes().to_vec()))
-    };
+    let atom = |s: &str| Rc::new(SExp::Atom(srcloc.clone(), s.as_bytes().to_vec()));
 
-    let sublist = |l: &[Rc<SExp>]| {
-        Rc::new(enlist(srcloc.clone(), l))
-    };
+    let sublist = |l: &[Rc<SExp>]| Rc::new(enlist(srcloc.clone(), l));
 
     let nil = Rc::new(SExp::Nil(srcloc.clone()));
 
     let program = sublist(&[
-        atom("mod"), nil.clone(),
+        atom("mod"),
+        nil.clone(),
         sublist(&[atom("include"), atom("*strict-cl-21*")]),
-        sublist(&[atom("+"), atom(""), Rc::new(SExp::Integer(srcloc.clone(), bi_one()))])
+        sublist(&[
+            atom("+"),
+            atom(""),
+            Rc::new(SExp::Integer(srcloc.clone(), bi_one())),
+        ]),
     ]);
     let mut allocator = Allocator::new();
     let mut symbols = HashMap::new();
     let runner = Rc::new(DefaultProgramRunner::new());
 
-    let compiled = opts.compile_program(
-        &mut allocator,
-        runner.clone(),
-        program,
-        &mut symbols,
-    ).expect("should compile");
+    let compiled = opts
+        .compile_program(&mut allocator, runner.clone(), program, &mut symbols)
+        .expect("should compile");
     let outcome = run(
         &mut allocator,
         runner,
@@ -2349,9 +2346,7 @@ fn test_handle_explicit_empty_atom() {
         nil,
         None,
         None,
-    ).expect("should run");
-    assert_eq!(
-        outcome.to_string(),
-        "1"
-    );
+    )
+    .expect("should run");
+    assert_eq!(outcome.to_string(), "1");
 }

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use clvm_rs::allocator::Allocator;
 
+use crate::classic::clvm::__type_compatibility__::bi_one;
 use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
 use crate::compiler::clvm::run;
 use crate::compiler::compiler::{compile_file, DefaultCompilerOpts};
@@ -11,7 +12,7 @@ use crate::compiler::dialect::AcceptedDialect;
 use crate::compiler::frontend::{collect_used_names_sexp, frontend};
 use crate::compiler::rename::rename_in_cons;
 use crate::compiler::runtypes::RunFailure;
-use crate::compiler::sexp::{decode_string, parse_sexp, SExp};
+use crate::compiler::sexp::{decode_string, enlist, parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
 
 const TEST_TIMEOUT: usize = 1000000;
@@ -2303,4 +2304,54 @@ fn test_rename_in_compileform_simple() {
         .collect();
     let renamed_helperform = squash_name_differences(helper_f[0].to_sexp()).expect("should rename");
     assert_eq!(renamed_helperform.to_string(), desired_outcome);
+}
+
+
+#[test]
+fn test_handle_explicit_empty_atom() {
+    let filename = "*empty-atom-test*";
+    let srcloc = Srcloc::start(filename);
+    let opts = Rc::new(DefaultCompilerOpts::new(filename)).set_dialect(AcceptedDialect {
+        stepping: Some(21),
+        strict: true,
+    });
+
+    let atom = |s: &str| {
+        Rc::new(SExp::Atom(srcloc.clone(), s.as_bytes().to_vec()))
+    };
+
+    let sublist = |l: &[Rc<SExp>]| {
+        Rc::new(enlist(srcloc.clone(), l))
+    };
+
+    let nil = Rc::new(SExp::Nil(srcloc.clone()));
+
+    let program = sublist(&[
+        atom("mod"), nil.clone(),
+        sublist(&[atom("include"), atom("*strict-cl-21*")]),
+        sublist(&[atom("+"), atom(""), Rc::new(SExp::Integer(srcloc.clone(), bi_one()))])
+    ]);
+    let mut allocator = Allocator::new();
+    let mut symbols = HashMap::new();
+    let runner = Rc::new(DefaultProgramRunner::new());
+
+    let compiled = opts.compile_program(
+        &mut allocator,
+        runner.clone(),
+        program,
+        &mut symbols,
+    ).expect("should compile");
+    let outcome = run(
+        &mut allocator,
+        runner,
+        opts.prim_map(),
+        Rc::new(compiled),
+        nil,
+        None,
+        None,
+    ).expect("should run");
+    assert_eq!(
+        outcome.to_string(),
+        "1"
+    );
 }


### PR DESCRIPTION
When something internal generates an empty atom, it should be handled as nil.