### PR TITLE
20240123 add compile from text base

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -142,6 +142,7 @@ jobs:
 
     # Test cldb output both run from python and via its command line tool.
     - name: "Run step run tests"
+      shell: bash
       run: |
         . ./activate
         cargo build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -152,7 +152,10 @@ jobs:
         pip install --no-index --find-links target/wheels/ clvm_tools_rs
         pip install clvm_rs
         pip install clvm_tools
-        cd resources/tests && python test_clvm_step.py && python mandelbrot-cldb.py
+        cd resources/tests && \
+            python test_clvm_step.py && \
+            python mandelbrot-cldb.py && \
+            python test_compile_from_from_string.py
 
     - name: "Test step run with mandelbrot, setting print only"
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -142,7 +142,6 @@ jobs:
 
     # Test cldb output both run from python and via its command line tool.
     - name: "Run step run tests"
-      shell: bash
       run: |
         . ./activate
         cargo build
@@ -153,10 +152,7 @@ jobs:
         pip install --no-index --find-links target/wheels/ clvm_tools_rs
         pip install clvm_rs
         pip install clvm_tools
-        cd resources/tests && \
-            python test_clvm_step.py && \
-            python mandelbrot-cldb.py && \
-            python test_compile_from_string.py
+        cd resources/tests && python test_clvm_step.py && python mandelbrot-cldb.py && python test_compile_from_string.py
 
     - name: "Test step run with mandelbrot, setting print only"
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -155,7 +155,7 @@ jobs:
         cd resources/tests && \
             python test_clvm_step.py && \
             python mandelbrot-cldb.py && \
-            python test_compile_from_from_string.py
+            python test_compile_from_string.py
 
     - name: "Test step run with mandelbrot, setting print only"
       run: |

--- a/resources/tests/test_compile_from_string.py
+++ b/resources/tests/test_compile_from_string.py
@@ -21,6 +21,9 @@ expected_cl23 = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ffff04ff0bff8080808080fff
 
 expected_deinline = "ff02ffff01ff02ff02ffff04ff02ffff04ff03ffff04ffff10ff05ffff01830f424080ff8080808080ffff04ffff01ff10ff0bff0bff0bff0bff0bff0b80ff018080"
 
+classic_error = "(mod (X) (xxx X))"
+cl23_error = "(mod (X) (include *standard-cl-23*) (+ X X1))"
+
 compiled_code = clvm_tools_rs.compile(
     classic_code,
     ["."],
@@ -70,3 +73,16 @@ dependencies = clvm_tools_rs.check_dependencies(
 )
 assert len(dependencies) == 1
 assert Path(dependencies[0]) == game_referee / 'reverse.clinc'
+
+# Better error reporting
+try:
+    clvm_tools_rs.compile(classic_error, [])
+    assert False
+except Exception as e:
+    assert e.args[0] == "error can't compile (\"xxx\" 88), unknown operator compiling (\"xxx\" 88)"
+
+try:
+    clvm_tools_rs.compile(cl23_error, [])
+    assert False
+except Exception as e:
+    assert e.args[0] == "*inline*(1):42-*inline*(1):44: Unbound use of X1 as a variable name"

--- a/resources/tests/test_compile_from_string.py
+++ b/resources/tests/test_compile_from_string.py
@@ -1,0 +1,45 @@
+import clvm_tools_rs
+import binascii
+
+classic_code = """
+(mod (N X)
+  (defun F (N X) (if N (sha256 (F (- N 1) X)) X))
+  (F N X)
+  )
+"""
+expected_classic = binascii.unhexlify("ff02ffff01ff02ff02ffff04ff02ffff04ff05ffff04ff0bff8080808080ffff04ffff01ff02ffff03ff05ffff01ff0bffff02ff02ffff04ff02ffff04ffff11ff05ffff010180ffff04ff0bff808080808080ffff010b80ff0180ff018080".encode("utf8"))
+
+cl23_code = """
+(mod (N X)
+  (include *standard-cl-23*)
+  (defun F (N X) (if N (sha256 (F (- N 1) X)) X))
+  (F N X)
+  )
+"""
+expected_cl23 = binascii.unhexlify("ff02ffff01ff02ff02ffff04ff02ffff04ff05ffff04ff0bff8080808080ffff04ffff01ff02ffff03ff05ffff01ff0bffff02ff02ffff04ff02ffff04ffff11ff05ffff010180ffff04ff0bff808080808080ffff010b80ff0180ff018080".encode("utf8"))
+
+compiled_code = clvm_tools_rs.compile(
+    classic_code,
+    ["."],
+    True
+)
+# Classic outputs symbols to the filesystem down all routes, which likely should
+# be fixed.
+assert bytes(compiled_code["output"]) == expected_classic
+
+compiled_code = clvm_tools_rs.compile(
+    classic_code,
+    ["."]
+)
+assert bytes(compiled_code) == expected_classic
+
+compiled_code = clvm_tools_rs.compile(
+    cl23_code,
+    ["."],
+    True
+)
+symbols = compiled_code["symbols"]
+assert symbols["__chia__main_arguments"] == "(N X)"
+assert symbols["30960d7f2ddc7188a6428a11d39a13ff70d308e6cc571ffb6ed5ec8dbe4376c0_arguments"] == "(N X)"
+assert symbols["30960d7f2ddc7188a6428a11d39a13ff70d308e6cc571ffb6ed5ec8dbe4376c0"] == "F"
+assert bytes(compiled_code["output"]) == expected_cl23

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -22,7 +22,52 @@ use crate::compiler::comptypes::{CompileErr, CompilerOpts};
 use crate::compiler::dialect::detect_modern;
 use crate::compiler::optimize::maybe_finalize_program_via_classic_optimizer;
 use crate::compiler::runtypes::RunFailure;
+use crate::compiler::srcloc::Srcloc;
 use crate::util::gentle_overwrite;
+
+#[derive(Debug, Clone)]
+pub enum CompileError {
+    Modern(Srcloc, String),
+    Classic(NodePtr, String),
+}
+
+impl From<EvalErr> for CompileError {
+    fn from(e: EvalErr) -> Self {
+        CompileError::Classic(e.0, e.1)
+    }
+}
+
+impl From<CompileErr> for CompileError {
+    fn from(r: CompileErr) -> Self {
+        CompileError::Modern(r.0, r.1)
+    }
+}
+
+impl From<RunFailure> for CompileError {
+    fn from(r: RunFailure) -> Self {
+        match r {
+            RunFailure::RunErr(l, x) => CompileError::Modern(l, x),
+            RunFailure::RunExn(l, x) => CompileError::Modern(l, x.to_string()),
+        }
+    }
+}
+
+impl CompileError {
+    pub fn format(&self, allocator: &Allocator, opts: Rc<dyn CompilerOpts>) -> String {
+        match self {
+            CompileError::Classic(node, message) => {
+                format!(
+                    "error {} compiling {}",
+                    message,
+                    disassemble(allocator, *node, opts.disassembly_ver())
+                )
+            }
+            CompileError::Modern(loc, message) => {
+                format!("{}: {}", loc, message)
+            }
+        }
+    }
+}
 
 pub fn write_sym_output(
     compiled_lookup: &HashMap<String, String>,
@@ -44,7 +89,7 @@ pub fn compile_clvm_text_maybe_opt(
     text: &str,
     input_path: &str,
     classic_with_opts: bool,
-) -> Result<NodePtr, EvalErr> {
+) -> Result<NodePtr, CompileError> {
     let ir_src = read_ir(text).map_err(|s| EvalErr(allocator.null(), s.to_string()))?;
     let assembled_sexp = assemble_from_ir(allocator, Rc::new(ir_src))?;
 
@@ -61,18 +106,16 @@ pub fn compile_clvm_text_maybe_opt(
             .set_optimize(do_optimize || stepping > 22) // Would apply to cl23
             .set_frontend_opt(stepping == 22);
 
-        let unopt_res = compile_file(allocator, runner.clone(), opts.clone(), text, symbol_table);
-        let res = unopt_res.and_then(|x| {
-            maybe_finalize_program_via_classic_optimizer(allocator, runner, opts, do_optimize, &x)
-        });
+        let unopt_res = compile_file(allocator, runner.clone(), opts.clone(), text, symbol_table)?;
+        let res = maybe_finalize_program_via_classic_optimizer(
+            allocator,
+            runner,
+            opts,
+            do_optimize,
+            &unopt_res,
+        )?;
 
-        res.and_then(|x| {
-            convert_to_clvm_rs(allocator, x).map_err(|r| match r {
-                RunFailure::RunErr(l, x) => CompileErr(l, x),
-                RunFailure::RunExn(l, x) => CompileErr(l, x.to_string()),
-            })
-        })
-        .map_err(|s| EvalErr(allocator.null(), s.1))
+        Ok(convert_to_clvm_rs(allocator, res)?)
     } else {
         let compile_invoke_code = run(allocator);
         let input_sexp = allocator.new_pair(assembled_sexp, allocator.null())?;
@@ -93,7 +136,7 @@ pub fn compile_clvm_text(
     text: &str,
     input_path: &str,
     classic_with_opts: bool,
-) -> Result<NodePtr, EvalErr> {
+) -> Result<NodePtr, CompileError> {
     compile_clvm_text_maybe_opt(
         allocator,
         true,
@@ -122,13 +165,7 @@ pub fn compile_clvm_inner(
         filename,
         classic_with_opts,
     )
-    .map_err(|x| {
-        format!(
-            "error {} compiling {}",
-            x.1,
-            disassemble(allocator, x.0, opts.disassembly_ver())
-        )
-    })?;
+    .map_err(|e| e.format(allocator, opts))?;
     sexp_to_stream(allocator, result, result_stream);
     Ok(())
 }

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use clvm_rs::allocator::{Allocator, NodePtr};
 use clvm_rs::reduction::EvalErr;
 
-use crate::classic::clvm::__type_compatibility__::{Bytes, Stream, BytesFromType};
+use crate::classic::clvm::__type_compatibility__::Stream;
 use crate::classic::clvm::serialize::sexp_to_stream;
 use crate::classic::clvm_tools::binutils::{assemble_from_ir, disassemble};
 use crate::classic::clvm_tools::ir::reader::read_ir;
@@ -159,8 +159,8 @@ pub fn compile_clvm(
             false,
         )?;
 
-        result_stream.write(Bytes::new(Some(BytesFromType::Raw(b"\n".to_vec()))));
-        let target_data = result_stream.get_value().hex();
+        let mut target_data = result_stream.get_value().hex();
+        target_data += "\n";
 
         // Try to detect whether we'd put the same output in the output file.
         // Don't proceed if true.

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -115,13 +115,13 @@ fn run_clvm_compilation(
             // Output is a program represented as clvm data in allocator.
             let clvm_result = clvmc::compile_clvm_text(
                 &mut allocator,
-                opts,
+                opts.clone(),
                 &mut symbols,
                 &file_content,
                 &path_string,
                 true,
             )
-            .map_err(|e| CompError::new_err(format!("{}", e)))?;
+            .map_err(|e| CompError::new_err(e.format(&allocator, opts)))?;
 
             // Get the text representation, which will go either to the output file
             // or result.

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -86,7 +86,8 @@ fn get_source_from_input(input_code: CompileClvmSource) -> PyResult<(String, Str
                 path_string += ".clvm";
             }
 
-            let file_data = fs::read_to_string(&path_string).map_err(|e| PyException::new_err(format!("error reading {path_string}: {e:?}")))?;
+            let file_data = fs::read_to_string(&path_string)
+                .map_err(|e| PyException::new_err(format!("error reading {path_string}: {e:?}")))?;
             Ok((path_string, file_data))
         }
         CompileClvmSource::SourceCode(name, code) => Ok((name.clone(), code.clone())),
@@ -132,7 +133,8 @@ fn run_clvm_compilation(
             let compiled = if let Some(output_file) = output {
                 // Write output with eol.
                 hex_text += "\n";
-                gentle_overwrite(&path_string, &output_file, &hex_text).map_err(PyException::new_err)?;
+                gentle_overwrite(&path_string, &output_file, &hex_text)
+                    .map_err(PyException::new_err)?;
                 output_file.to_string()
             } else {
                 hex_text

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -105,16 +105,13 @@ fn compile(
 
     let mut allocator = Allocator::new();
     let input_name = "*inline*";
-    let def_opts: Rc<dyn CompilerOpts> =
-        Rc::new(DefaultCompilerOpts::new(input_name));
+    let def_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(input_name));
     let opts = def_opts.set_search_paths(&search_paths);
-    let mut includes = Vec::new();
 
     let compiled_node = clvmc::compile_clvm_text(
         &mut allocator,
         opts,
         &mut symbols,
-        &mut includes,
         &source,
         input_name,
         true,
@@ -128,8 +125,7 @@ fn compile(
     })
     .map_err(PyException::new_err)?;
 
-    let blob =
-        node_to_bytes(&allocator, compiled_node).map_err(PyException::new_err)?;
+    let blob = node_to_bytes(&allocator, compiled_node).map_err(PyException::new_err)?;
 
     Python::with_gil(|py| {
         if export_symbols == Some(true) {

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -17,9 +17,8 @@ use std::thread;
 use clvm_rs::allocator::Allocator;
 use clvm_rs::serde::node_to_bytes;
 
-use crate::classic::clvm::__type_compatibility__::{Bytes, Stream, UnvalidatedBytesFromType};
+use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType, Stream, UnvalidatedBytesFromType};
 use crate::classic::clvm::serialize::sexp_to_stream;
-use crate::classic::clvm_tools::binutils::disassemble;
 use crate::classic::clvm_tools::clvmc;
 use crate::classic::clvm_tools::cmds;
 use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
@@ -52,6 +51,117 @@ fn get_version() -> PyResult<String> {
     Ok(version())
 }
 
+enum CompileClvmSource<'a> {
+    SourcePath(&'a PyAny),
+    SourceCode(String, String),
+}
+
+enum CompileClvmAction {
+    CheckDependencies,
+    CompileCode(Option<String>)
+}
+
+fn get_source_from_input(input_code: CompileClvmSource) -> PyResult<(String, String)> {
+    match input_code {
+        CompileClvmSource::SourcePath(input_path) => {
+            let has_atom = input_path.hasattr("atom")?;
+            let has_pair = input_path.hasattr("pair")?;
+
+            let real_input_path = if has_atom {
+                input_path.getattr("atom").and_then(|x| x.str())
+            } else if has_pair {
+                input_path
+                    .getattr("pair")
+                    .and_then(|x| x.get_item(0))
+                    .and_then(|x| x.str())
+            } else {
+                input_path.extract()
+            }?;
+
+            let mut path_string = real_input_path.to_string();
+
+            if !std::path::Path::new(&path_string).exists() && !path_string.ends_with(".clvm") {
+                path_string += ".clvm";
+            }
+
+            let file_data = fs::read_to_string(&path_string).map_err(PyException::new_err)?;
+            Ok((path_string, file_data))
+        }
+        CompileClvmSource::SourceCode(name, code) => {
+            Ok((name.clone(), code.clone()))
+        }
+    }
+}
+
+fn run_clvm_compilation(
+    input_code: CompileClvmSource,
+    action: CompileClvmAction,
+    search_paths: Vec<String>,
+    export_symbols: Option<bool>,
+) -> PyResult<PyObject> {
+    // Resolve the input, get the indicated path and content.
+    let (path_string, file_content) = get_source_from_input(input_code)?;
+
+    // Load up our compiler opts.
+    let def_opts: Rc<dyn CompilerOpts> =
+        Rc::new(DefaultCompilerOpts::new(&path_string));
+    let opts = def_opts.set_search_paths(&search_paths);
+
+    match action {
+        CompileClvmAction::CompileCode(output) => {
+            let mut allocator = Allocator::new();
+            let mut symbols = HashMap::new();
+
+            // Output is a program represented as clvm data in allocator.
+            let clvm_result =
+                clvmc::compile_clvm_text(
+                    &mut allocator,
+                    opts,
+                    &mut symbols,
+                    &file_content,
+                    &path_string,
+                    true
+                ).map_err(|e| CompError::new_err(format!("{}", e)))?;
+
+            // Get the text representation, which will go either to the output file
+            // or result.
+            let mut hex_text = Bytes::new(Some(BytesFromType::Raw(node_to_bytes(&allocator, clvm_result)?))).hex();
+            let compiled =
+                if let Some(output_file) = output {
+                    // Write output with eol.
+                    hex_text += "\n";
+                    fs::write(&output_file, hex_text).map_err(PyException::new_err)?;
+                    output_file.to_string()
+                } else {
+                    hex_text
+                };
+
+            // Produce compiled output according to whether output with symbols
+            // or just the standard result is required.
+            Python::with_gil(|py| {
+                if export_symbols == Some(true) {
+                    let mut result_dict = HashMap::new();
+                    result_dict.insert("output".to_string(), compiled.into_py(py));
+                    result_dict.insert("symbols".to_string(), symbols.into_py(py));
+                    Ok(result_dict.into_py(py))
+                } else {
+                    Ok(compiled.into_py(py))
+                }
+            })
+        }
+        CompileClvmAction::CheckDependencies => {
+            // Produce dependency results.
+            let result_deps: Vec<String> =
+                gather_dependencies(opts, &path_string.to_string(), &file_content)
+                .map_err(|e| CompError::new_err(format!("{}: {}", e.0, e.1)))
+                .map(|rlist| rlist.iter().map(|i| decode_string(&i.name)).collect())?;
+
+            // Return all visited files.
+            Python::with_gil(|py| Ok(result_deps.into_py(py)))
+        }
+    }
+}
+
 #[pyfunction(arg3 = "[]", arg4 = "None")]
 fn compile_clvm(
     input_path: &PyAny,
@@ -59,40 +169,12 @@ fn compile_clvm(
     search_paths: Vec<String>,
     export_symbols: Option<bool>,
 ) -> PyResult<PyObject> {
-    let has_atom = input_path.hasattr("atom")?;
-    let has_pair = input_path.hasattr("pair")?;
-
-    let real_input_path = if has_atom {
-        input_path.getattr("atom").and_then(|x| x.str())
-    } else if has_pair {
-        input_path
-            .getattr("pair")
-            .and_then(|x| x.get_item(0))
-            .and_then(|x| x.str())
-    } else {
-        input_path.extract()
-    }?;
-
-    let mut path_string = real_input_path.to_string();
-
-    if !std::path::Path::new(&path_string).exists() && !path_string.ends_with(".clvm") {
-        path_string += ".clvm";
-    };
-
-    let mut symbols = HashMap::new();
-    let compiled = clvmc::compile_clvm(&path_string, &output_path, &search_paths, &mut symbols)
-        .map_err(PyException::new_err)?;
-
-    Python::with_gil(|py| {
-        if export_symbols == Some(true) {
-            let mut result_dict = HashMap::new();
-            result_dict.insert("output".to_string(), compiled.into_py(py));
-            result_dict.insert("symbols".to_string(), symbols.into_py(py));
-            Ok(result_dict.into_py(py))
-        } else {
-            Ok(compiled.into_py(py))
-        }
-    })
+    run_clvm_compilation(
+        CompileClvmSource::SourcePath(input_path),
+        CompileClvmAction::CompileCode(Some(output_path)),
+        search_paths,
+        export_symbols
+    )
 }
 
 #[pyfunction(arg2 = "[]", arg3 = "None")]
@@ -101,74 +183,22 @@ fn compile(
     search_paths: Vec<String>,
     export_symbols: Option<bool>,
 ) -> PyResult<PyObject> {
-    let mut symbols = HashMap::new();
-
-    let mut allocator = Allocator::new();
-    let input_name = "*inline*";
-    let def_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(input_name));
-    let opts = def_opts.set_search_paths(&search_paths);
-
-    let compiled_node = clvmc::compile_clvm_text(
-        &mut allocator,
-        opts,
-        &mut symbols,
-        &source,
-        input_name,
-        true,
+    run_clvm_compilation(
+        CompileClvmSource::SourceCode("*inline*".to_string(), source),
+        CompileClvmAction::CompileCode(None),
+        search_paths,
+        export_symbols
     )
-    .map_err(|x| {
-        format!(
-            "error {} compiling {}",
-            x.1,
-            disassemble(&mut allocator, x.0, None)
-        )
-    })
-    .map_err(PyException::new_err)?;
-
-    let blob = node_to_bytes(&allocator, compiled_node).map_err(PyException::new_err)?;
-
-    Python::with_gil(|py| {
-        if export_symbols == Some(true) {
-            let mut result_dict = HashMap::new();
-            result_dict.insert("output".to_string(), blob.into_py(py));
-            result_dict.insert("symbols".to_string(), symbols.into_py(py));
-            Ok(result_dict.into_py(py))
-        } else {
-            Ok(blob.into_py(py))
-        }
-    })
 }
 
 #[pyfunction(arg2 = "[]")]
 fn check_dependencies(input_path: &PyAny, search_paths: Vec<String>) -> PyResult<PyObject> {
-    let has_atom = input_path.hasattr("atom")?;
-    let has_pair = input_path.hasattr("pair")?;
-
-    let real_input_path = if has_atom {
-        input_path.getattr("atom").and_then(|x| x.str())
-    } else if has_pair {
-        input_path
-            .getattr("pair")
-            .and_then(|x| x.get_item(0))
-            .and_then(|x| x.str())
-    } else {
-        input_path.extract()
-    }?;
-
-    let file_content = fs::read_to_string(&real_input_path.to_string())
-        .map_err(|_| CompError::new_err("failed to read file"))?;
-
-    let def_opts: Rc<dyn CompilerOpts> =
-        Rc::new(DefaultCompilerOpts::new(&real_input_path.to_string()));
-    let opts = def_opts.set_search_paths(&search_paths);
-
-    let result_deps: Vec<String> =
-        gather_dependencies(opts, &real_input_path.to_string(), &file_content)
-            .map_err(|e| CompError::new_err(format!("{}: {}", e.0, e.1)))
-            .map(|rlist| rlist.iter().map(|i| decode_string(&i.name)).collect())?;
-
-    // Return all visited files.
-    Python::with_gil(|py| Ok(result_deps.into_py(py)))
+    run_clvm_compilation(
+        CompileClvmSource::SourcePath(input_path),
+        CompileClvmAction::CheckDependencies,
+        search_paths,
+        None,
+    )
 }
 
 #[pyclass]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -150,7 +150,11 @@ where
     }
 }
 
-pub fn atomic_write_file(input_path: &str, output_path: &str, target_data: &str) -> Result<(), String> {
+pub fn atomic_write_file(
+    input_path: &str,
+    output_path: &str,
+    target_data: &str,
+) -> Result<(), String> {
     let output_path_obj = Path::new(output_path);
     let output_dir = output_path_obj
         .parent()
@@ -159,9 +163,8 @@ pub fn atomic_write_file(input_path: &str, output_path: &str, target_data: &str)
 
     // Make the contents appear atomically so that other test processes
     // won't mistake an empty file for intended output.
-    let mut temp_output_file = NamedTempFile::new_in(output_dir).map_err(|e| {
-        format!("error creating temporary compiler output for {input_path}: {e:?}")
-    })?;
+    let mut temp_output_file = NamedTempFile::new_in(output_dir)
+        .map_err(|e| format!("error creating temporary compiler output for {input_path}: {e:?}"))?;
 
     let err_text = format!("failed to write to {:?}", temp_output_file.path());
     let translate_err = |_| err_text.clone();
@@ -170,9 +173,9 @@ pub fn atomic_write_file(input_path: &str, output_path: &str, target_data: &str)
         .write_all(target_data.as_bytes())
         .map_err(translate_err)?;
 
-    temp_output_file.persist(output_path).map_err(|e| {
-        format!("error persisting temporary compiler output {output_path}: {e:?}")
-    })?;
+    temp_output_file
+        .persist(output_path)
+        .map_err(|e| format!("error persisting temporary compiler output {output_path}: {e:?}"))?;
 
     Ok(())
 }
@@ -180,7 +183,7 @@ pub fn atomic_write_file(input_path: &str, output_path: &str, target_data: &str)
 pub fn gentle_overwrite(
     input_path: &str,
     output_path: &str,
-    target_data: &str
+    target_data: &str,
 ) -> Result<(), String> {
     if let Ok(prev_content) = fs::read_to_string(output_path) {
         let prev_trimmed = prev_content.trim();
@@ -190,12 +193,12 @@ pub fn gentle_overwrite(
             // work.  This will accomodate both the read only scenario and
             // the scenario where a target file is newer and people want the
             // date to be updated.
-            atomic_write_file(input_path, output_path, &target_data).ok();
+            atomic_write_file(input_path, output_path, target_data).ok();
 
             // It's the same program, bail regardless.
             return Ok(());
         }
     }
 
-    atomic_write_file(input_path, output_path, &target_data)
+    atomic_write_file(input_path, output_path, target_data)
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,10 @@
 use num_bigint::BigInt;
 use std::collections::HashSet;
+use std::fs;
+use std::io::Write;
 use std::mem::swap;
+use std::path::Path;
+use tempfile::NamedTempFile;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub type Number = BigInt;
@@ -144,4 +148,54 @@ where
     fn err_into(self) -> Result<DestRes, DestErr> {
         self.map_err(|e| e.into())
     }
+}
+
+pub fn atomic_write_file(input_path: &str, output_path: &str, target_data: &str) -> Result<(), String> {
+    let output_path_obj = Path::new(output_path);
+    let output_dir = output_path_obj
+        .parent()
+        .map(Ok)
+        .unwrap_or_else(|| Err("could not get parent of output path"))?;
+
+    // Make the contents appear atomically so that other test processes
+    // won't mistake an empty file for intended output.
+    let mut temp_output_file = NamedTempFile::new_in(output_dir).map_err(|e| {
+        format!("error creating temporary compiler output for {input_path}: {e:?}")
+    })?;
+
+    let err_text = format!("failed to write to {:?}", temp_output_file.path());
+    let translate_err = |_| err_text.clone();
+
+    temp_output_file
+        .write_all(target_data.as_bytes())
+        .map_err(translate_err)?;
+
+    temp_output_file.persist(output_path).map_err(|e| {
+        format!("error persisting temporary compiler output {output_path}: {e:?}")
+    })?;
+
+    Ok(())
+}
+
+pub fn gentle_overwrite(
+    input_path: &str,
+    output_path: &str,
+    target_data: &str
+) -> Result<(), String> {
+    if let Ok(prev_content) = fs::read_to_string(output_path) {
+        let prev_trimmed = prev_content.trim();
+        let trimmed = target_data.trim();
+        if prev_trimmed == trimmed {
+            // We should try to overwrite here, but not fail if it doesn't
+            // work.  This will accomodate both the read only scenario and
+            // the scenario where a target file is newer and people want the
+            // date to be updated.
+            atomic_write_file(input_path, output_path, &target_data).ok();
+
+            // It's the same program, bail regardless.
+            return Ok(());
+        }
+    }
+
+    atomic_write_file(input_path, output_path, &target_data)
 }


### PR DESCRIPTION
Add a "compile" entrypoint which compiles from source rather than a path name.
Add a test entry point for this facility and fit to current api.  It's likely that there'll be a couple more commits on here to merge
the filename and source code compile entrypoints from python.

This was envisioned by @richardkiss https://github.com/richardkiss/clvm_tools_rs/commit/6f95cef9e049afff43801b7c86bb9972718dc913 
