### PR TITLE
20240419 cldb revision

### DIFF
--- a/src/classic/clvm_tools/cmds.rs
+++ b/src/classic/clvm_tools/cmds.rs
@@ -754,22 +754,23 @@ pub fn cldb(args: &[String]) {
             return;
         }
 
-        if let Some(result) = cldbrun.step(&mut allocator) {
+        if let Some(mut result) = cldbrun.step(&mut allocator) {
             if only_print {
-                if let Some(p) = result.get("Print") {
+                if let Some(p) = result.print() {
                     let mut only_print = BTreeMap::new();
                     only_print.insert("Print".to_string(), YamlElement::String(p.clone()));
                     output.push(only_print);
                 } else {
-                    let is_final = result.contains_key("Final");
-                    let is_throw = result.contains_key("Throw");
-                    let is_failure = result.contains_key("Failure");
+                    let dict = result.dict();
+                    let is_final = dict.contains_key("Final");
+                    let is_throw = dict.contains_key("Throw");
+                    let is_failure = dict.contains_key("Failure");
                     if is_final || is_throw || is_failure {
-                        print_tree(&mut output, &result);
+                        print_tree(&mut output, result.dict());
                     }
                 }
             } else {
-                print_tree(&mut output, &result);
+                print_tree(&mut output, result.dict());
             }
         }
     }

--- a/src/compiler/cldb.rs
+++ b/src/compiler/cldb.rs
@@ -99,7 +99,7 @@ pub trait CldbEnvironment {
 pub struct CldbRun {
     runner: Rc<dyn TRunProgram>,
     prim_map: Rc<HashMap<Vec<u8>, Rc<SExp>>>,
-    env: Box<dyn CldbEnvironment>,
+    env: Rc<dyn CldbEnvironment>,
 
     step: RunStep,
 
@@ -154,6 +154,13 @@ impl StepInfo {
     pub fn dict(&mut self) -> &BTreeMap<String, String> {
         &self.dict
     }
+
+    pub fn into_dict(&mut self) -> BTreeMap<String, String> {
+        // Swap in an empty dict and give the user our dict.
+        let mut empty = BTreeMap::new();
+        swap(&mut empty, &mut self.dict);
+        empty
+    }
 }
 
 impl CldbRun {
@@ -170,7 +177,7 @@ impl CldbRun {
         CldbRun {
             runner,
             prim_map,
-            env,
+            env: env.into(),
             step,
             ended: false,
             final_result: None,

--- a/src/compiler/cldb.rs
+++ b/src/compiler/cldb.rs
@@ -101,7 +101,7 @@ pub struct CldbRun {
     prim_map: Rc<HashMap<Vec<u8>, Rc<SExp>>>,
     env: Rc<dyn CldbEnvironment>,
 
-    step: RunStep,
+    step: Rc<RunStep>,
 
     ended: bool,
     final_result: Option<Rc<SExp>>,
@@ -178,7 +178,7 @@ impl CldbRun {
             runner,
             prim_map,
             env: env.into(),
-            step,
+            step: step.into(),
             ended: false,
             final_result: None,
             to_print: BTreeMap::new(),
@@ -318,7 +318,7 @@ impl CldbRun {
             }
         }
 
-        self.step = new_step.unwrap_or_else(|_| self.step.clone());
+        self.step = new_step.map(|s| s.into()).unwrap_or_else(|_| self.step.clone());
 
         if produce_result {
             self.row += 1;
@@ -328,8 +328,8 @@ impl CldbRun {
         }
     }
 
-    pub fn current_step(&self) -> RunStep {
-        self.step.clone()
+    pub fn current_step(&self) -> &RunStep {
+        self.step.borrow()
     }
 }
 

--- a/src/compiler/cldb.rs
+++ b/src/compiler/cldb.rs
@@ -143,6 +143,19 @@ fn is_print_request(a: &SExp) -> Option<(Srcloc, Rc<SExp>)> {
     None
 }
 
+pub struct StepInfo {
+    dict: BTreeMap<String, String>
+}
+impl StepInfo {
+    pub fn print(&mut self) -> Option<String> {
+        self.dict.get("Print").cloned()
+    }
+
+    pub fn dict(&mut self) -> &BTreeMap<String, String> {
+        &self.dict
+    }
+}
+
 impl CldbRun {
     /// Create a new CldbRun for running a program.
     /// Takes an CldbEnvironment and a prepared RunStep, which will be stepped
@@ -185,7 +198,7 @@ impl CldbRun {
         !self.print_only
     }
 
-    pub fn step(&mut self, allocator: &mut Allocator) -> Option<BTreeMap<String, String>> {
+    pub fn step(&mut self, allocator: &mut Allocator) -> Option<StepInfo> {
         let mut produce_result = false;
         let mut result = BTreeMap::new();
         let new_step = match self.env.get_override(&self.step) {
@@ -302,7 +315,7 @@ impl CldbRun {
 
         if produce_result {
             self.row += 1;
-            Some(result)
+            Some(StepInfo { dict: result })
         } else {
             None
         }

--- a/src/compiler/cldb_hierarchy.rs
+++ b/src/compiler/cldb_hierarchy.rs
@@ -389,10 +389,13 @@ impl HierarchialRunner {
         } else {
             // Not final result, we'll step the top of the stack.
             let info = self.running[idx].run.step(&mut self.allocator);
-            if let Some(i) = &info {
-                self.error |= i.get("Failure").is_some();
+            if let Some(mut i) = info {
+                let dict = i.dict();
+                self.error |= dict.get("Failure").is_some();
+                Ok(HierarchialStepResult::Info(Some(dict.clone())))
+            } else {
+                Ok(HierarchialStepResult::Info(None))
             }
-            Ok(HierarchialStepResult::Info(info))
         }
     }
 }

--- a/src/compiler/cldb_hierarchy.rs
+++ b/src/compiler/cldb_hierarchy.rs
@@ -365,7 +365,7 @@ impl HierarchialRunner {
             self.running[idx].env = outcome;
 
             let step = clvm::step_return_value(
-                &self.running[idx].run.current_step(),
+                self.running[idx].run.current_step(),
                 self.running[idx].env.clone(),
             );
 
@@ -381,7 +381,7 @@ impl HierarchialRunner {
             );
 
             Ok(HierarchialStepResult::ShapeChange)
-        } else if let Some(info) = relevant_run_step_info(&self.symbol_table, &current_step) {
+        } else if let Some(info) = relevant_run_step_info(&self.symbol_table, current_step) {
             // Create a frame based on the last argument.
             self.push_synthetic_stack_frame(current_env, &info);
 

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -371,7 +371,7 @@ fn start_clvm_program(
 
                     let result = cldbrun.step(&mut allocator);
                     let is_ended = cldbrun.is_ended();
-                    match result_output.send((is_ended, result)) {
+                    match result_output.send((is_ended, result.map(|mut r| r.into_dict()))) {
                         Ok(_) => {}
                         Err(_) => {
                             return;

--- a/src/tests/compiler/cldb.rs
+++ b/src/tests/compiler/cldb.rs
@@ -74,8 +74,8 @@ where
             return output.get("Final").cloned();
         }
 
-        if let Some(result) = cldbrun.step(&mut allocator) {
-            output = result;
+        if let Some(mut result) = cldbrun.step(&mut allocator) {
+            output = result.dict().clone();
             if !viewer.show(&cldbrun.current_step(), Some(output.clone())) {
                 return None;
             }

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -270,6 +270,7 @@ pub fn run_step(runner: i32) -> JsValue {
 
         r.cldbrun.step(&mut r.allocator)
     })
+    .map(|mut r| r.into_dict())
     .map(|result_hash| btreemap_to_object(result_hash.iter()))
     .unwrap_or_else(JsValue::null)
 }


### PR DESCRIPTION
Ensure cldb's compiler observes the program's sigil rather than assuming vaguely modern-ish.
Add a --tail option to cldb which causes cldb to evaluation to text until we know how many rows to convert.
Make the result of cldb step a StepInfo which holds the information needed to create the yaml entry that cldb usually outputs rather than the actual data structure.  This allows users to finalize this information lazily.