### PR TITLE
Create source distribution with --sdist

### DIFF
--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build_wheels:
     name: Build wheel on Mac M1
-    runs-on: [MacOS, ARM64]
+    runs-on: macos-13-arm64
     strategy:
       fail-fast: false
 

--- a/.github/workflows/build-riscv.yml
+++ b/.github/workflows/build-riscv.yml
@@ -71,7 +71,7 @@ jobs:
           python -m venv venv && \
           source ./venv/bin/activate && \
           pip install --upgrade pip && \
-          pip install --extra-index-url https://pypi.chia.net/simple/ maturin==1.2.3 && \
+          pip install --extra-index-url https://pypi.chia.net/simple/ maturin==1.5.0 && \
           maturin build -i python --release --strip \
           '
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Build Linux in manylinux_2_28 with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        docker run --rm -v $(pwd):/io ghcr.io/pyo3/maturin:v1.7.0 build --release --strip --manylinux 2_28
+        docker run --rm -v $(pwd):/io ghcr.io/pyo3/maturin:v1.7.0 build --release --strip --manylinux 2_28 --sdist
         # Refresh in case any ownerships changed.
         mv target target.docker && cp -r target.docker target
         # Ensure an empty .cargo-lock file exists.
@@ -154,7 +154,7 @@ jobs:
         # Check that recompiling deployed puzzles match with their deployed hashes
         cp support/install_deps.sh support/verify_compiler_version.sh chia-blockchain
         (cd chia-blockchain && python -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && \
-          python -m pip install maturin==1.1.0 && \
+          python -m pip install maturin==1.7.0 && \
           cd .. && pip install --no-index --find-links target/wheels/ clvm_tools_rs && \
           cd chia-blockchain && \
           # deps for manage_clvm.py

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, ubuntu-latest, windows-latest]
+        os: [macos-13, ubuntu-latest, windows-latest]
         python: [3.8, 3.9, '3.10', 3.11]
 
     steps:
@@ -56,7 +56,7 @@ jobs:
     - name: Build MacOs with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'macos')
       env:
-        MACOSX_DEPLOYMENT_TARGET: '11.0'
+        MACOSX_DEPLOYMENT_TARGET: '13.0'
       run: |
         maturin build -i python --release --strip
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.3.2,<1.4.0"]
+requires = ["maturin>=1.3.2"]
 build-backend = "maturin"
 
 [tool.maturin]


### PR DESCRIPTION
Update `pyproject.toml` maturin versions to reflect already using maturin 1.7.0 in build workflows.
Update riscv workflow maturin version
Also update to use macos-13
and most importantly - on Linux, use the `--sdist` option to create a source distribution for this package to upload to pypi