### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET for Apple Silicon

### DIFF
--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -48,6 +48,8 @@ jobs:
         rm rustup-init checksum.txt
 
     - name: Build m1 wheels
+      env:
+        MACOSX_DEPLOYMENT_TARGET: '13.0'
       run: |
         python3 -m venv venv
         . ./venv/bin/activate


### PR DESCRIPTION
For consistency with Intel builds, set the MACOSX_DEPLOYMENT_TARGET to 13