### PR TITLE
Update to python 3.9 as the base

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ lfsr = { version = "0.3.0", optional = true }
 
 [dependencies.pyo3]
 version = "0.21.2"
-features = ["abi3-py38", "extension-module"]
+features = ["abi3-py39", "extension-module"]
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
Update pyo3 features to offer python compatibility starting at version 3.9.