### PR TITLE
20250625 fix non repro

### DIFF
--- a/src/compiler/dialect.rs
+++ b/src/compiler/dialect.rs
@@ -116,6 +116,20 @@ lazy_static! {
                     .to_string(),
                 },
             ),
+            (
+                "*standard-cl-25*",
+                DialectDescription {
+                    accepted: AcceptedDialect {
+                        stepping: Some(25),
+                        strict: true,
+                        int_fix: true,
+                    },
+                    content: indoc! {"(
+                    (defconstant *chialisp-version* 25)
+                )"}
+                    .to_string(),
+                },
+            ),
         ];
         for (n, v) in dialect_list.iter() {
             dialects.insert(n.to_string(), v.clone());

--- a/src/compiler/optimize/deinline.rs
+++ b/src/compiler/optimize/deinline.rs
@@ -41,6 +41,8 @@ fn stepping_over_24(opts: Rc<dyn CompilerOpts>) -> bool {
     false
 }
 
+type VecOfRootSetTree<'a> = Vec<(&'a BTreeSet<Vec<u8>>, Vec<&'a Vec<u8>>)>;
+
 // Should take a desugared program.
 pub fn deinline_opt(
     context: &mut BasicCompileContext,
@@ -189,16 +191,20 @@ pub fn deinline_opt(
         })
         .collect();
 
-    let mut root_set_to_inline_tree_vec: Vec<(&BTreeSet<Vec<u8>>, Vec<&Vec<u8>>)> = root_set_to_inline_tree.iter().map(|(k, function_set)| {
-        let mut fset_vec: Vec<&Vec<u8>> = function_set.iter().collect();
+    let mut root_set_to_inline_tree_vec: VecOfRootSetTree<'_> =
+        root_set_to_inline_tree
+            .iter()
+            .map(|(k, function_set)| {
+                let mut fset_vec: Vec<&Vec<u8>> = function_set.iter().collect();
 
-        // Sort which normalizes order.
-        if stepping_over_24(opts.clone()) {
-            fset_vec.sort();
-        }
+                // Sort which normalizes order.
+                if stepping_over_24(opts.clone()) {
+                    fset_vec.sort();
+                }
 
-        (k, fset_vec)
-    }).collect();
+                (k, fset_vec)
+            })
+            .collect();
 
     // Sort which normalizes order.
     if stepping_over_24(opts.clone()) {

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -2622,19 +2622,12 @@ fn test_keccak_opversion() {
     assert_eq!(program.trim(), "FAIL: unimplemented operator 62");
 }
 
-#[cfg(debug_assertions)]
-const PATH_TO_RUN: &'static str = "./target/debug/run";
-#[cfg(not(debug_assertions))]
-const PATH_TO_RUN: &'static str = "./target/release/run";
-
 #[test]
 fn test_reproduce_variable_repr_bug_deinline() {
     let source_program = "(mod (A) (include *standard-cl-24*) (defun F (X Y Z)
     (assign Q X R Q (list R Y Z))) (F &rest A))";
 
-    let compile = |p: &str| {
-        do_basic_run(&vec!["run".to_string(), p.to_string()])
-    };
+    let compile = |p: &str| do_basic_run(&vec!["run".to_string(), p.to_string()]);
 
     let mut output = compile(&source_program);
     // Produce the same program 30 times.  Demonstrates that this program didn't

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -2621,3 +2621,37 @@ fn test_keccak_opversion() {
     ]);
     assert_eq!(program.trim(), "FAIL: unimplemented operator 62");
 }
+
+#[cfg(debug_assertions)]
+const PATH_TO_RUN: &'static str = "./target/debug/run";
+#[cfg(not(debug_assertions))]
+const PATH_TO_RUN: &'static str = "./target/release/run";
+
+#[test]
+fn test_reproduce_variable_repr_bug_deinline() {
+    let source_program = "(mod (A) (include *standard-cl-24*) (defun F (X Y Z)
+    (assign Q X R Q (list R Y Z))) (F &rest A))";
+
+    let compile = |p: &str| {
+        do_basic_run(&vec!["run".to_string(), p.to_string()])
+    };
+
+    let mut output = compile(&source_program);
+    // Produce the same program 30 times.  Demonstrates that this program didn't
+    // produce a stable output (otherwise we wouldn't know the bug was fixed).
+    let mut different = false;
+    for _ in 0..30 {
+        different |= output != compile(&source_program);
+    }
+
+    assert!(different);
+
+    // Bump sigil
+    let new_program = &source_program.replace("cl-24", "cl-25");
+
+    let mut output = compile(&new_program);
+    // Produce the same program 30 times.  The output should not be unstable.
+    for _ in 0..30 {
+        assert_eq!(output, compile(&new_program));
+    }
+}


### PR DESCRIPTION
Fix a bug that allows a differently ordered traversal of the dependency graph to sometimes result in the production of a different program during deinlining.  Add sigil 25 which switches the fix on.