### PR TITLE
The serializer now sets a limit on size

### DIFF
--- a/resources/tests/cmdline/tests/serialize_test.py
+++ b/resources/tests/cmdline/tests/serialize_test.py
@@ -45,7 +45,7 @@ class SerializeTest(unittest.TestCase):
             self.check_serde(t1)
 
     def test_very_long_blobs(self):
-        for size in [0x40, 0x2000, 0x100000, 0x8000000]:
+        for size in [0x40, 0x2000, 0x100000]:
             count = size // len(TEXT)
             text = TEXT * count
             assert len(text) < size

--- a/resources/tests/cmdline/tests/serialize_test.py
+++ b/resources/tests/cmdline/tests/serialize_test.py
@@ -11,12 +11,12 @@ TEXT = b"the quick brown fox jumps over the lazy dogs"
 class SerializeTest(unittest.TestCase):
     def check_serde(self, s):
         v = to_sexp_f(s)
-        b = v.as_bin()
+        b = v.as_bin(max_size=0x4000000)
         v1 = sexp_from_stream(io.BytesIO(b), to_sexp_f)
         if v != v1:
             print("%s: %d %s %s" % (v, len(b), b, v1))
             breakpoint()
-            b = v.as_bin(max_size=0x4000000)
+            b = v.as_bin()
             v1 = sexp_from_stream(io.BytesIO(b), to_sexp_f)
         self.assertEqual(v, v1)
 

--- a/resources/tests/cmdline/tests/serialize_test.py
+++ b/resources/tests/cmdline/tests/serialize_test.py
@@ -11,7 +11,7 @@ TEXT = b"the quick brown fox jumps over the lazy dogs"
 class SerializeTest(unittest.TestCase):
     def check_serde(self, s):
         v = to_sexp_f(s)
-        b = v.as_bin(max_size=0x4000000)
+        b = v.as_bin(max_size=0x40000000)
         v1 = sexp_from_stream(io.BytesIO(b), to_sexp_f)
         if v != v1:
             print("%s: %d %s %s" % (v, len(b), b, v1))

--- a/resources/tests/cmdline/tests/serialize_test.py
+++ b/resources/tests/cmdline/tests/serialize_test.py
@@ -16,7 +16,7 @@ class SerializeTest(unittest.TestCase):
         if v != v1:
             print("%s: %d %s %s" % (v, len(b), b, v1))
             breakpoint()
-            b = v.as_bin()
+            b = v.as_bin(max_size=0x4000000)
             v1 = sexp_from_stream(io.BytesIO(b), to_sexp_f)
         self.assertEqual(v, v1)
 
@@ -45,7 +45,7 @@ class SerializeTest(unittest.TestCase):
             self.check_serde(t1)
 
     def test_very_long_blobs(self):
-        for size in [0x40, 0x2000, 0x100000]:
+        for size in [0x40, 0x2000, 0x100000, 0x8000000]:
             count = size // len(TEXT)
             text = TEXT * count
             assert len(text) < size

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -63,7 +63,7 @@ impl CompileError {
                 )
             }
             CompileError::Modern(loc, message) => {
-                format!("{}: {}", loc, message)
+                format!("{loc}: {message}")
             }
         }
     }

--- a/src/classic/clvm_tools/cmds.rs
+++ b/src/classic/clvm_tools/cmds.rs
@@ -895,7 +895,7 @@ fn perform_preprocessing(
         with_stepping,
     );
 
-    stdout.write_str(&format!("{}", whole_mod));
+    stdout.write_str(&format!("{whole_mod}"));
     Ok(())
 }
 

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -117,14 +117,14 @@ pub fn create_clvm_runner_err(error: String) -> JsValue {
 
 fn create_clvm_runner_run_failure(err: &RunFailure) -> JsValue {
     match err {
-        RunFailure::RunErr(l, e) => create_clvm_runner_err(format!("{}: Error {}", l, e)),
-        RunFailure::RunExn(l, e) => create_clvm_runner_err(format!("{}: Exn {}", l, e)),
+        RunFailure::RunErr(l, e) => create_clvm_runner_err(format!("{l}: Error {e}")),
+        RunFailure::RunExn(l, e) => create_clvm_runner_err(format!("{l}: Exn {e}")),
     }
 }
 
 fn create_clvm_compile_failure(err: &CompileErr) -> JsValue {
     match err {
-        CompileErr(l, e) => create_clvm_runner_err(format!("{}: Error {}", l, e)),
+        CompileErr(l, e) => create_clvm_runner_err(format!("{l}: Error {e}")),
     }
 }
 
@@ -199,7 +199,7 @@ pub fn create_clvm_runner(
         Err(e) => {
             return create_clvm_runner_run_failure(&RunFailure::RunErr(
                 args_srcloc.clone(),
-                format!("failed to read symbol table: {}", e),
+                format!("failed to read symbol table: {e}"),
             ));
         }
     };
@@ -354,7 +354,7 @@ pub fn compose_run_function(
         _ => {
             return create_clvm_compile_failure(&CompileErr(
                 loc.clone(),
-                format!("function not found in symbols: {}", function_name),
+                format!("function not found in symbols: {function_name}"),
             ));
         }
     };
@@ -387,8 +387,7 @@ pub fn compose_run_function(
             return create_clvm_compile_failure(&CompileErr(
                 program.loc(),
                 format!(
-                    "could not find function with hash from symbols: {}",
-                    function_name
+                    "could not find function with hash from symbols: {function_name}"
                 ),
             ));
         }

--- a/wasm/src/jsval.rs
+++ b/wasm/src/jsval.rs
@@ -244,7 +244,7 @@ pub fn read_string_to_string_map(
                 result.insert(key, val);
             }
             _ => {
-                return Err(format!("key {} wasn't string", key));
+                return Err(format!("key {key} wasn't string"));
             }
         }
     }


### PR DESCRIPTION
A max_size named parameter was added to SExp::as_bin which allows override of the max size.