### PR TITLE
Set toolchain versions

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+
+[toolchain]
+channel = "stable-2025-08-07"
+components = [ "rustfmt", "rustc", "rust-std", "rust-analyzer", "rustc-dev" ]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -114,12 +114,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86eaaa00a83a7511e8eb74ccb1ebe4358d927f43e06d45da5350e19ef2df1ca"
 dependencies = [
  "blst",
- "chia-sha2",
- "chia-traits",
+ "chia-sha2 0.22.0",
+ "chia-traits 0.22.0",
  "hex",
  "hkdf",
  "linked-hash-map",
- "sha2 0.10.8",
+ "sha2 0.10.9",
+ "thiserror",
+]
+
+[[package]]
+name = "chia-bls"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38840e8c8c5c6eb61304d85102230e74c2015c2bfb945292777f83f48915544c"
+dependencies = [
+ "blst",
+ "chia-sha2 0.28.2",
+ "chia-traits 0.28.2",
+ "hex",
+ "hkdf",
+ "linked-hash-map",
+ "sha2 0.10.9",
  "thiserror",
 ]
 
@@ -129,7 +145,16 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b37c5362dfb1c9449902139e94a91bbd8d3773c13939972fd88e4f14c4f9d"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "chia-sha2"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f03c71bc63599a711caad15dafca1d2a948c26b4c8a021709a338149632769"
+dependencies = [
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -138,8 +163,19 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "340ad823ef953d2ab9f937deae99b04bab73c0bf1a6aea1353331a5f875192e0"
 dependencies = [
- "chia-sha2",
- "chia_streamable_macro",
+ "chia-sha2 0.22.0",
+ "chia_streamable_macro 0.22.0",
+ "thiserror",
+]
+
+[[package]]
+name = "chia-traits"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52463c56cdf35aac55ecb35ffc0a615f0780f33f144503957e83f5b1ad92da3c"
+dependencies = [
+ "chia-sha2 0.28.2",
+ "chia_streamable_macro 0.28.2",
  "thiserror",
 ]
 
@@ -156,11 +192,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "chia_streamable_macro"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b807a9c04440d3f30b5534b84b462b996b34eee7fe0b7f8737ae6dfc6b9d4"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clvm_tools_rs"
 version = "0.4.0"
 dependencies = [
  "binascii",
- "chia-bls",
+ "chia-bls 0.22.0",
  "clvmr",
  "do-notation",
  "getrandom 0.2.15",
@@ -198,14 +246,14 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267d46b9946d172db86048e88aab94be58de181c3e81bdc6e97d622b03a67ba"
+checksum = "880b88f21f052e70cd348f4d23fc2f0ea11669e29da2cf7234e02eb425f2c6c6"
 dependencies = [
  "bitvec",
  "bumpalo",
- "chia-bls",
- "chia-sha2",
+ "chia-bls 0.28.2",
+ "chia-sha2 0.28.2",
  "hex",
  "hex-literal",
  "k256",
@@ -537,7 +585,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -710,7 +758,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -962,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/wasm/rust-toolchain.toml
+++ b/wasm/rust-toolchain.toml
@@ -1,0 +1,5 @@
+
+[toolchain]
+channel = "stable-2025-08-07"
+components = [ "rustfmt", "rustc", "rust-std", "rust-analyzer", "rustc-dev" ]
+targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
I believe this will keep clippy from revving on its own, so there shouldn't be any other spontaneous sources of build failures in the pipe.