### PR TITLE
Route SWI_PRINT_EXPR diagnostics to GDB console output

### DIFF
--- a/src/compiler/debug/armjit/emu.rs
+++ b/src/compiler/debug/armjit/emu.rs
@@ -83,6 +83,7 @@ pub struct Emu {
     pub jit_symbols: Rc<HashMap<String, EmuSymbolInfo>>,
 
     pub prim_map: Rc<HashMap<Vec<u8>, Rc<SExp>>>,
+    pending_gdb_console_output: Vec<String>,
 }
 
 impl SingleThreadBase for Emu {
@@ -318,6 +319,7 @@ impl Emu {
             clvm_symbols,
 
             prim_map: DefaultCompilerOpts::new("*emu*").prim_map(),
+            pending_gdb_console_output: Vec::new(),
         })
     }
 
@@ -326,6 +328,10 @@ impl Emu {
         self.cpu.reg_set(Mode::User, reg::LR, HLE_RETURN_ADDR);
         self.cpu.reg_set(Mode::User, reg::PC, self.start_addr);
         self.cpu.reg_set(Mode::User, reg::CPSR, 0x10);
+    }
+
+    pub(crate) fn take_pending_gdb_console_output(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.pending_gdb_console_output)
     }
 
     fn allocate_and_write(&mut self, alloc_ptr: u32, sexp: Rc<SExp>) -> u32 {
@@ -613,7 +619,10 @@ impl Emu {
             self.do_apply_op(runner, &srcloc, operator, args)
         } else if value == SWI_PRINT_EXPR {
             let r0_value = self.cpu.reg_get(Mode::User, 0);
-            eprintln!("PRINT: {}", self.get_sexp(&srcloc, r0_value));
+            let printed_expr = self.get_sexp(&srcloc, r0_value).to_string();
+            self.pending_gdb_console_output
+                .push(format!("PRINT: {printed_expr}"));
+            eprintln!("PRINT: {printed_expr}");
             self.cpu.reg_set(Mode::User, reg::PC, pc + 4);
             None
         } else {

--- a/src/compiler/debug/armjit/emu_stub.rs
+++ b/src/compiler/debug/armjit/emu_stub.rs
@@ -26,6 +26,50 @@ fn wait_for_tcp(port: u16) -> DynResult<TcpStream> {
 
 enum EmuGdbEventLoop {}
 
+fn hex_ascii(nibble: u8) -> u8 {
+    match nibble {
+        0..=9 => b'0' + nibble,
+        10..=15 => b'a' + (nibble - 10),
+        _ => b'0',
+    }
+}
+
+fn send_gdb_console_packet<C: Connection<Error = std::io::Error>>(
+    conn: &mut C,
+    message: &str,
+) -> Result<(), std::io::Error> {
+    let payload = message.as_bytes();
+    let mut checksum = b'O';
+    conn.write(b'$')?;
+    conn.write(b'O')?;
+    for byte in payload {
+        checksum = checksum.wrapping_add(*byte >> 4);
+        checksum = checksum.wrapping_add(*byte & 0x0f);
+        conn.write(hex_ascii(*byte >> 4))?;
+        conn.write(hex_ascii(*byte & 0x0f))?;
+    }
+    let newline = b'\n';
+    checksum = checksum.wrapping_add(newline >> 4);
+    checksum = checksum.wrapping_add(newline & 0x0f);
+    conn.write(hex_ascii(newline >> 4))?;
+    conn.write(hex_ascii(newline & 0x0f))?;
+    conn.write(b'#')?;
+    conn.write(hex_ascii(checksum >> 4))?;
+    conn.write(hex_ascii(checksum & 0x0f))?;
+    conn.flush()?;
+    Ok(())
+}
+
+fn flush_pending_gdb_console_output<C: Connection<Error = std::io::Error>>(
+    target: &mut Emu,
+    conn: &mut C,
+) -> Result<(), std::io::Error> {
+    for message in target.take_pending_gdb_console_output() {
+        send_gdb_console_packet(conn, &message)?;
+    }
+    Ok(())
+}
+
 fn print_run_event(event: &RunEvent) -> String {
     match event {
         RunEvent::IncomingData => "IncomingData".to_string(),
@@ -79,6 +123,8 @@ impl run_blocking::BlockingEventLoop for EmuGdbEventLoop {
         };
 
         let run_res = target.run(poll_incoming_data);
+        flush_pending_gdb_console_output(target, conn)
+            .map_err(run_blocking::WaitForStopReasonError::Connection)?;
         eprintln!("GDB {}", print_run_event(&run_res));
         match run_res {
             RunEvent::IncomingData => {

--- a/src/compiler/debug/armjit/emu_stub.rs
+++ b/src/compiler/debug/armjit/emu_stub.rs
@@ -43,16 +43,20 @@ fn send_gdb_console_packet<C: Connection<Error = std::io::Error>>(
     conn.write(b'$')?;
     conn.write(b'O')?;
     for byte in payload {
-        checksum = checksum.wrapping_add(*byte >> 4);
-        checksum = checksum.wrapping_add(*byte & 0x0f);
-        conn.write(hex_ascii(*byte >> 4))?;
-        conn.write(hex_ascii(*byte & 0x0f))?;
+        let hi = hex_ascii(*byte >> 4);
+        let lo = hex_ascii(*byte & 0x0f);
+        checksum = checksum.wrapping_add(hi);
+        checksum = checksum.wrapping_add(lo);
+        conn.write(hi)?;
+        conn.write(lo)?;
     }
     let newline = b'\n';
-    checksum = checksum.wrapping_add(newline >> 4);
-    checksum = checksum.wrapping_add(newline & 0x0f);
-    conn.write(hex_ascii(newline >> 4))?;
-    conn.write(hex_ascii(newline & 0x0f))?;
+    let newline_hi = hex_ascii(newline >> 4);
+    let newline_lo = hex_ascii(newline & 0x0f);
+    checksum = checksum.wrapping_add(newline_hi);
+    checksum = checksum.wrapping_add(newline_lo);
+    conn.write(newline_hi)?;
+    conn.write(newline_lo)?;
     conn.write(b'#')?;
     conn.write(hex_ascii(checksum >> 4))?;
     conn.write(hex_ascii(checksum & 0x0f))?;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- capture `SWI_PRINT_EXPR` output in `Emu` as pending debugger-console messages
- flush queued messages from the GDB stub event loop over remote protocol `O` packets
- keep existing stderr `PRINT:` logging while also delivering diagnostics to the connected GDB client
- corrected `O` packet checksum calculation to sum transmitted ASCII-hex payload bytes

## Changes
- `src/compiler/debug/armjit/emu.rs`
  - added `pending_gdb_console_output: Vec<String>` to `Emu`
  - initialized the queue in `Emu::new`
  - added `take_pending_gdb_console_output` to drain pending messages
  - updated the `SWI_PRINT_EXPR` trap arm to queue `PRINT: <sexp>` messages
- `src/compiler/debug/armjit/emu_stub.rs`
  - added helpers to emit RSP console `O` packets
  - flush pending `Emu` console messages in `wait_for_stop_reason` after target execution slices
  - fixed checksum computation to use emitted ASCII-hex byte values

## Validation
- built `armtx`: `cargo build --bin armtx`
- ran stub: `./resources/tests/test_sdc.sh`
- ran gdb: `./resources/tests/test_sdc_gdb.sh`
- in GDB, issued `continue` and observed console diagnostics including:
  - `PRINT: 1000000`
  - `PRINT: 5`
  - `PRINT: 1000005` (repeated)
  - `PRINT: 6000030`
- target reached end of program and terminated under GDB with SIGSTOP stop reason
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e8022f2-11a9-4a19-8c1b-e83ad3c41fcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e8022f2-11a9-4a19-8c1b-e83ad3c41fcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

