### PR TITLE
Update build environment to use ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build_wheels:
     name: Build ARM64 Python Wheels
-    runs-on: [ARM64, Linux]
+    runs-on: ubuntu-24.04-arm
     container:
       image: ghcr.io/chia-network/build-images/centos-pypa-rust-aarch64:latest
 


### PR DESCRIPTION
Use default GH arm runner name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates the GitHub Actions runner label; failures would be limited to the ARM64 wheel build workflow if the new runner is unavailable or behaves differently.
> 
> **Overview**
> Updates the ARM64 wheel build GitHub Actions workflow to run on the default `ubuntu-24.04-arm` runner instead of the prior custom `[ARM64, Linux]` label, aligning the build job with GitHub-hosted ARM runner naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5a1e3123cff035301a0f29c1d06225120ce1546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->