### PR TITLE
armjit gdb: keep stub alive and support restart with run

### DIFF
--- a/resources/tests/test_sdc_interactive.sh
+++ b/resources/tests/test_sdc_interactive.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+gdb-multiarch \
+  --ex "set pagination off" \
+  --ex "set confirm off" \
+  --ex "file sdc.elf" \
+  --ex "source support/gdb_print_sexp.py" \
+  --ex "dir resources/tests" \
+  --ex "target extended-remote :9001" \
+  --ex "run" \
+  --ex "run" \
+  --ex "quit" 2>&1

--- a/src/compiler/debug/armjit/emu.rs
+++ b/src/compiler/debug/armjit/emu.rs
@@ -21,6 +21,7 @@ use gdbstub::target::ext::base::{single_register_access, BaseOps};
 use gdbstub::target::ext::breakpoints::{
     Breakpoints, BreakpointsOps, HwBreakpointOps, HwWatchpointOps, SwBreakpoint, SwBreakpointOps,
 };
+use gdbstub::target::ext::extended_mode::{Args, AttachKind, ExtendedModeOps, ShouldTerminate};
 use gdbstub::target::{Target, TargetResult};
 
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType};
@@ -65,6 +66,7 @@ pub enum ExecMode {
 pub struct Emu {
     start_addr: u32,
     next_module_addr: u32,
+    initial_mem: PagedMemory,
 
     // example custom register. only read/written to from the GDB client
     pub custom_reg: u32,
@@ -183,6 +185,13 @@ impl Target for Emu {
     fn support_breakpoints(&mut self) -> Option<BreakpointsOps<Self>> {
         Some(self)
     }
+
+    #[inline(always)]
+    fn support_extended_mode(
+        &mut self,
+    ) -> Option<ExtendedModeOps<'_, Self>> {
+        Some(self)
+    }
 }
 
 impl SwBreakpoint for Emu {
@@ -250,6 +259,41 @@ impl SingleThreadResume for Emu {
     }
 }
 
+impl gdbstub::target::ext::extended_mode::ExtendedMode for Emu {
+    fn run(&mut self, _filename: Option<&[u8]>, args: Args<'_, '_>) -> TargetResult<Pid, Self> {
+        // This emulator doesn't spawn a new process; "run" is implemented as a reset.
+        let _ = args.count();
+        self.reset();
+        Ok(self.reported_pid)
+    }
+
+    fn attach(&mut self, pid: Pid) -> TargetResult<(), Self> {
+        if pid == self.reported_pid {
+            Ok(())
+        } else {
+            Err(().into())
+        }
+    }
+
+    fn query_if_attached(&mut self, pid: Pid) -> TargetResult<AttachKind, Self> {
+        if pid == self.reported_pid {
+            Ok(AttachKind::Run)
+        } else {
+            Err(().into())
+        }
+    }
+
+    fn kill(&mut self, _pid: Option<Pid>) -> TargetResult<ShouldTerminate, Self> {
+        self.reset();
+        Ok(ShouldTerminate::No)
+    }
+
+    fn restart(&mut self) -> Result<(), Self::Error> {
+        self.reset();
+        Ok(())
+    }
+}
+
 fn is_apply_operator(sexp: Rc<SExp>) -> bool {
     if let SExp::Cons(_, h, t) = &*sexp {
         if is_apply(&h) {
@@ -290,6 +334,7 @@ impl Emu {
         // copy all in-memory sections from the ELF file into system RAM
         let mut elf_loader = ElfLoader::new(program_elf, start_addr).expect("should load");
         elf_loader.load(&mut mem);
+        let initial_mem = mem.clone();
 
         let jit_symbols = Rc::new(elf_loader.get_symbols());
 
@@ -309,6 +354,7 @@ impl Emu {
 
             cpu,
             mem,
+            initial_mem,
 
             watchpoints: Vec::new(),
             breakpoints: Vec::new(),
@@ -324,6 +370,9 @@ impl Emu {
     }
 
     pub(crate) fn reset(&mut self) {
+        self.mem = self.initial_mem.clone();
+        self.exec_mode = ExecMode::Continue;
+        self.pending_gdb_console_output.clear();
         self.cpu.reg_set(Mode::User, reg::SP, 0xffffff00);
         self.cpu.reg_set(Mode::User, reg::LR, HLE_RETURN_ADDR);
         self.cpu.reg_set(Mode::User, reg::PC, self.start_addr);

--- a/src/compiler/debug/armjit/emu.rs
+++ b/src/compiler/debug/armjit/emu.rs
@@ -187,9 +187,7 @@ impl Target for Emu {
     }
 
     #[inline(always)]
-    fn support_extended_mode(
-        &mut self,
-    ) -> Option<ExtendedModeOps<'_, Self>> {
+    fn support_extended_mode(&mut self) -> Option<ExtendedModeOps<'_, Self>> {
         Some(self)
     }
 }

--- a/src/compiler/debug/armjit/emu_stub.rs
+++ b/src/compiler/debug/armjit/emu_stub.rs
@@ -144,7 +144,7 @@ impl run_blocking::BlockingEventLoop for EmuGdbEventLoop {
                 let stop_reason = match event {
                     Event::Trap => SingleThreadStopReason::Signal(Signal::SIGABRT),
                     Event::DoneStep => SingleThreadStopReason::DoneStep,
-                    Event::Halted => SingleThreadStopReason::Terminated(Signal::SIGSTOP),
+                    Event::Halted => SingleThreadStopReason::Signal(Signal::SIGSTOP),
                     Event::Break => SingleThreadStopReason::SwBreak(()),
                     Event::WatchWrite(addr) => SingleThreadStopReason::Watch {
                         tid: (),

--- a/src/compiler/debug/armjit/memory.rs
+++ b/src/compiler/debug/armjit/memory.rs
@@ -16,6 +16,7 @@ pub trait TargetMemory {
     fn read_u8(&self, target_addr: u32) -> u8;
 }
 
+#[derive(Clone)]
 pub struct PagedMemory {
     zeroed: Vec<u32>,
     pages: HashMap<u32, Vec<u32>>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add GDB extended-mode support to the ARM JIT emulator target so `target extended-remote` + `run` resets and re-runs the same program
- make emulator reset restore a pristine memory snapshot (not just registers), reset execution mode, and clear pending GDB console output
- change `Event::Halted` mapping from a terminating stop reason to a non-terminal signal stop, keeping the stub session alive after completion
- add `resources/tests/test_sdc_interactive.sh` to exercise running to completion and then restarting/running again in one GDB session
- apply rustfmt cleanup required by CI (`fmt` step)

## Testing
- `cargo build --bin armtx && ./resources/tests/test_sdc.sh` (starts emulator/stub and waits for GDB)
- `./resources/tests/test_sdc_interactive.sh` against the same stub session
  - observed first completion with `CLVM: 6000030`
  - used `run` in GDB to restart and observed second completion with `CLVM: 6000030`
- `cargo +stable fmt -- --files-with-diff --check`

## Notes
- This implementation intentionally models restart semantics via GDB extended mode (`run`/`restart`) while staying single-process/single-thread in the emulator.
- `attach`/`query_if_attached` are constrained to the emulator’s single synthetic PID.
- CI warnings about deprecated GitHub Actions runtime (`Node.js 20` / `set-output`) are repository workflow issues and not caused by this code change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b434595e-32bd-4e06-940e-0e65de88aa81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b434595e-32bd-4e06-940e-0e65de88aa81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

