### PR TITLE
Fix synthetic SWI argument-chain generation in armjit emulator

### DIFF
--- a/src/compiler/debug/armjit/emu.rs
+++ b/src/compiler/debug/armjit/emu.rs
@@ -461,6 +461,11 @@ impl Emu {
                 value_addr = self.mem.r32(value_addr + 4);
             }
             let apply_operator = is_apply_operator(to_run.clone());
+            let arg_addresses: Vec<u32> = address_list
+                .iter()
+                .skip(1)
+                .map(|arg_cons_addr| self.mem.r32(*arg_cons_addr))
+                .collect();
 
             if (value_addr & 1) != 0 && (value_addr >> 1) != 0 {
                 // Not a proper list.
@@ -500,7 +505,7 @@ impl Emu {
             instruction_list.push(Instr::Subi(Register::R(6), Register::PC, 48));
 
             // Arguments in env are in a proper list.  Emit code to iterate it from end to start,
-            for (i, arg) in address_list.iter().enumerate().rev() {
+            for i in (0..arg_addresses.len()).rev() {
                 instruction_list.push(Instr::Ldr(
                     Register::R(1),
                     Register::R(6),
@@ -511,7 +516,7 @@ impl Emu {
                 instruction_list.push(Instr::Swi(SWI_DISPATCH_NEW_CODE));
                 // Result is in R0.
                 // Allocate a cons and compose it.
-                instruction_list.push(Instr::Str(
+                instruction_list.push(Instr::Ldr(
                     Register::R(2),
                     Register::R(5),
                     NEXT_ALLOC_OFFSET,
@@ -526,15 +531,14 @@ impl Emu {
                 ));
                 // Set the head of the cons to the newly evaluated argument.
                 instruction_list.push(Instr::Str(Register::R(0), Register::R(2), 0));
-                // Load the cons ptr.
+                // Tail points at the currently built argument list.
                 instruction_list.push(Instr::Ldr(
-                    Register::R(0),
+                    Register::R(3),
                     Register::R(6),
                     4,
                 ));
-                // Set the tail
-                instruction_list.push(Instr::Str(Register::R(2), Register::R(0), 4));
-                // Set the new cons ptr
+                instruction_list.push(Instr::Str(Register::R(3), Register::R(2), 4));
+                // Set the new cons ptr.
                 instruction_list.push(Instr::Str(
                     Register::R(2),
                     Register::R(6),
@@ -583,10 +587,10 @@ impl Emu {
                 instruction_list.push(Instr::Swi(SWI_PRINT_EXPR));
 
                 // Load the args address into R1
-                instruction_list.push(Instr::Str(
+                instruction_list.push(Instr::Ldr(
                     Register::R(1),
                     Register::R(6),
-                    8,
+                    4,
                 ));
 
                 // Emit dispatch instruction.
@@ -603,7 +607,7 @@ impl Emu {
 
             instruction_list[0] =
                 Instr::Long(new_code_address as usize + 4 * instruction_list.len());
-            for arg in address_list.iter().skip(1).rev() {
+            for arg in arg_addresses.iter() {
                 instruction_list.push(Instr::Long(*arg as usize));
             }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix synthesized thunk argument indexing so only actual operator arguments are dispatched (not the operator cell itself)
- fix synthesized cons allocation to load `r2` from the allocator pointer before writing, and build tails from the existing list in `r6+4`
- fix synthesized non-apply dispatch setup to load `r1` from `r6+4` (argument list) instead of clobbering `r6+8`
- preserve correct literal argument-pointer table layout for generated thunks

## Validation
- `cargo build --bin armtx`
- `./resources/tests/test_synthetic_code.sh` (waits for gdb remote)
- gdb attach via `gdb-multiarch --batch --ex "file tsc.elf" --ex "source support/gdb_print_sexp.py" --ex "target remote :9001" --ex "continue" ...`
  - observed diagnostic output including `CLVM: 3`
  - run halts with `GDB Event(Halted)` instead of trapping with invalid synthesized operator

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8710dfa1-61f0-437e-b6d7-21acf48af22a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8710dfa1-61f0-437e-b6d7-21acf48af22a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

