### PR TITLE
update clvmr to 1.17.5

### DIFF
--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -33,7 +33,7 @@ jobs:
         echo "${PATH}"
         yum -y install openssl-devel
         source /root/.cargo/env
-        rustup default stable
+        rustup default 1.94.1
         rustup target add aarch64-unknown-linux-musl
         rm -rf venv
         export PATH="${PATH}:/opt/python/cp10-cp10/bin/"

--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -31,13 +31,13 @@ jobs:
     - name: Set up rusts
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.94.1
         components: rustfmt, clippy
 
     - name: Set up rust (stable)
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.94.1
         components: rustfmt, clippy
 
     - name: fmt (stable)

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.94.1
 
     - uses: actions/setup-python@v6
       name: Install Python ${{ matrix.python }}
@@ -342,7 +342,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-          toolchain: stable-2025-08-07-x86_64-unknown-linux-gnu
+          toolchain: 1.94.1-x86_64-unknown-linux-gnu
       - name: clippy
         run: |
           # Add --all-targets as a separate step
@@ -361,7 +361,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-          toolchain: stable-2025-08-07-x86_64-unknown-linux-gnu
+          toolchain: 1.94.1-x86_64-unknown-linux-gnu
       - name: cargo fmt
         run: cargo fmt --all -- --files-with-diff --check
 
@@ -375,7 +375,7 @@ jobs:
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+            toolchain: 1.94.1
             components: rustfmt, clippy
       - name: cargo test
         run: cargo test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up rusts
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.94.1
           components: rustfmt, clippy
 
       - name: install wasm-pack

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -82,9 +82,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "cc"
@@ -100,43 +106,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia-bls"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38840e8c8c5c6eb61304d85102230e74c2015c2bfb945292777f83f48915544c"
-dependencies = [
- "blst",
- "chia-sha2 0.28.2",
- "chia-traits 0.28.2",
- "hex",
- "hkdf",
- "linked-hash-map",
- "sha2",
- "thiserror",
-]
-
-[[package]]
-name = "chia-bls"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f02cbfd038d9050d45edbe8f38e09391c73479c0cca5b37925daf48c4d4fcd4"
 dependencies = [
  "blst",
- "chia-sha2 0.36.1",
- "chia-traits 0.36.1",
+ "chia-sha2",
+ "chia-traits",
  "hex",
  "hkdf",
  "linked-hash-map",
  "sha2",
  "thiserror",
-]
-
-[[package]]
-name = "chia-sha2"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f03c71bc63599a711caad15dafca1d2a948c26b4c8a021709a338149632769"
-dependencies = [
- "sha2",
 ]
 
 [[package]]
@@ -150,36 +131,13 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52463c56cdf35aac55ecb35ffc0a615f0780f33f144503957e83f5b1ad92da3c"
-dependencies = [
- "chia-sha2 0.28.2",
- "chia_streamable_macro 0.28.2",
- "thiserror",
-]
-
-[[package]]
-name = "chia-traits"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4922b447b2d8418213948af1a448c3ca7b84e149b51b2c87a2e00e80bb19b0"
 dependencies = [
- "chia-sha2 0.36.1",
- "chia_streamable_macro 0.36.1",
+ "chia-sha2",
+ "chia_streamable_macro",
  "thiserror",
-]
-
-[[package]]
-name = "chia_streamable_macro"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b807a9c04440d3f30b5534b84b462b996b34eee7fe0b7f8737ae6dfc6b9d4"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -199,7 +157,7 @@ name = "chialisp"
 version = "0.4.3"
 dependencies = [
  "binascii",
- "chia-bls 0.36.1",
+ "chia-bls",
  "clvmr",
  "do-notation",
  "getrandom 0.2.15",
@@ -228,18 +186,20 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.16.2"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf14f44f7c6b1d7972753cdd66f6afae38b117b752e6d1256b6f532dc3a0d304"
+checksum = "56b333963b083468df9a15602fcc3a24fa3f8c3964569fb9d2415ac70c0820e9"
 dependencies = [
+ "bitflags",
  "bitvec",
  "bumpalo",
- "chia-bls 0.28.2",
- "chia-sha2 0.28.2",
+ "chia-bls",
+ "chia-sha2",
  "hex",
  "hex-literal",
  "k256",
  "lazy_static",
+ "malachite-bigint",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -557,6 +517,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,7 +604,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b797be749e5d7d013b3e18954049468c228841a5068ceb55dd9da23a300ecff6"
 dependencies = [
- "itertools",
+ "itertools 0.8.2",
  "lfsr-base",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -648,7 +617,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3a3a6a85a7aac81c9f94adc14ab565eaaac8fd91460d06b89e4dd93462cdf8"
 dependencies = [
- "itertools",
+ "itertools 0.8.2",
  "lfsr-base",
  "lfsr-instances",
  "proc-macro2 0.4.30",
@@ -663,6 +632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +648,43 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "malachite-base"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b6f86fdbb1eb9955946be91775239dfcb0acdb1a51bb07d5fc9b8c854f5ccd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "libm",
+ "ryu",
+]
+
+[[package]]
+name = "malachite-bigint"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fcd6e504ffc67db2b3c6d5e90e08054646e2b04f42115a5460bf1c1e37d3bc"
+dependencies = [
+ "malachite-base",
+ "malachite-nz",
+ "num-integer",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0197a2f5cfee19d59178e282985c6ca79a9233e26a2adcf40acb693896aa09f6"
+dependencies = [
+ "itertools 0.14.0",
+ "libm",
+ "malachite-base",
+ "wide",
+]
 
 [[package]]
 name = "memchr"
@@ -790,6 +802,12 @@ dependencies = [
  "primeorder",
  "sha2",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1075,9 +1093,18 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "sec1"
@@ -1382,6 +1409,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wide"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ python-source = "python"
 [dependencies]
 binascii = "0.1.4"
 chia-bls = "0.36.0"
-clvmr = { version = "0.16.2", features = ["pre-eval"] }
+clvmr = { version = "0.17.5", features = ["pre-eval"] }
 do-notation = "0.1.3"
 hashlink = "0.11.0"
 hex = "0.4.3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 
 [toolchain]
-channel = "stable"
+channel = "1.94.1"
 components = [ "rustfmt", "rustc", "rust-std", "rust-analyzer", "rustc-dev" ]

--- a/src/classic/clvm_tools/stages/stage_0.rs
+++ b/src/classic/clvm_tools/stages/stage_0.rs
@@ -1,5 +1,5 @@
 use clvm_rs::allocator::{Allocator, NodePtr};
-use clvm_rs::chia_dialect::{ChiaDialect, ENABLE_KECCAK_OPS_OUTSIDE_GUARD, NO_UNKNOWN_OPS};
+use clvm_rs::chia_dialect::{ChiaDialect, ClvmFlags};
 use clvm_rs::core_ops::{op_cons, op_eq, op_first, op_if, op_listp, op_raise, op_rest};
 use clvm_rs::cost::Cost;
 use clvm_rs::dialect::{Dialect, OperatorSet};
@@ -14,6 +14,14 @@ use clvm_rs::reduction::{Reduction, Response};
 use clvm_rs::run_program::{run_program_with_pre_eval, PreEval};
 
 use crate::classic::clvm::OPERATORS_LATEST_VERSION;
+
+pub fn choose_run_flags(operators_version: usize) -> ClvmFlags {
+    if operators_version < 2 {
+        ClvmFlags::NO_UNKNOWN_OPS
+    } else {
+        ClvmFlags::NO_UNKNOWN_OPS | ClvmFlags::ENABLE_KECCAK_OPS_OUTSIDE_GUARD
+    }
+}
 
 #[derive(Default)]
 pub struct RunProgramOption {
@@ -48,11 +56,11 @@ impl Default for DefaultProgramRunner {
 }
 
 pub struct OriginalDialect {
-    flags: u32,
+    flags: ClvmFlags,
 }
 
 impl OriginalDialect {
-    pub fn new(flags: u32) -> Self {
+    pub fn new(flags: ClvmFlags) -> Self {
         OriginalDialect { flags }
     }
 }
@@ -62,10 +70,10 @@ fn unknown_operator(
     allocator: &mut Allocator,
     o: NodePtr,
     args: NodePtr,
-    flags: u32,
+    flags: ClvmFlags,
     max_cost: Cost,
 ) -> Response {
-    if (flags & NO_UNKNOWN_OPS) != 0 {
+    if (flags & ClvmFlags::NO_UNKNOWN_OPS) != ClvmFlags::empty() {
         Err(EvalErr::InternalError(
             o,
             "unimplemented operator".to_string(),
@@ -132,7 +140,7 @@ impl Dialect for OriginalDialect {
                 return unknown_operator(allocator, o, argument_list, self.flags, max_cost);
             }
         };
-        f(allocator, argument_list, max_cost)
+        f(allocator, argument_list, max_cost, self.flags())
     }
 
     fn quote_kw(&self) -> u32 {
@@ -152,7 +160,15 @@ impl Dialect for OriginalDialect {
     }
 
     fn allow_unknown_ops(&self) -> bool {
-        (self.flags & NO_UNKNOWN_OPS) == 0
+        (self.flags & ClvmFlags::NO_UNKNOWN_OPS) == ClvmFlags::empty()
+    }
+
+    fn flags(&self) -> ClvmFlags {
+        todo!();
+    }
+
+    fn gc_candidate(&self, _allocator: &Allocator, _node: NodePtr) -> bool {
+        false
     }
 }
 
@@ -187,7 +203,7 @@ impl TRunProgram for DefaultProgramRunner {
         match operators_version {
             0 => run_program_with_pre_eval_dialect(
                 allocator,
-                &OriginalDialect::new(NO_UNKNOWN_OPS),
+                &OriginalDialect::new(ClvmFlags::NO_UNKNOWN_OPS),
                 program,
                 args,
                 max_cost,
@@ -195,7 +211,7 @@ impl TRunProgram for DefaultProgramRunner {
             ),
             1 => run_program_with_pre_eval_dialect(
                 allocator,
-                &ChiaDialect::new(NO_UNKNOWN_OPS),
+                &ChiaDialect::new(ClvmFlags::NO_UNKNOWN_OPS),
                 program,
                 args,
                 max_cost,
@@ -203,7 +219,9 @@ impl TRunProgram for DefaultProgramRunner {
             ),
             _ => run_program_with_pre_eval_dialect(
                 allocator,
-                &ChiaDialect::new(NO_UNKNOWN_OPS | ENABLE_KECCAK_OPS_OUTSIDE_GUARD),
+                &ChiaDialect::new(
+                    ClvmFlags::NO_UNKNOWN_OPS | ClvmFlags::ENABLE_KECCAK_OPS_OUTSIDE_GUARD,
+                ),
                 program,
                 args,
                 max_cost,

--- a/src/classic/clvm_tools/stages/stage_0.rs
+++ b/src/classic/clvm_tools/stages/stage_0.rs
@@ -164,7 +164,7 @@ impl Dialect for OriginalDialect {
     }
 
     fn flags(&self) -> ClvmFlags {
-        todo!();
+        self.flags
     }
 
     fn gc_candidate(&self, _allocator: &Allocator, _node: NodePtr) -> bool {

--- a/src/classic/clvm_tools/stages/stage_2/operators.rs
+++ b/src/classic/clvm_tools/stages/stage_2/operators.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use clvm_rs::allocator::{Allocator, NodePtr, SExp};
-use clvm_rs::chia_dialect::{ChiaDialect, NO_UNKNOWN_OPS};
+use clvm_rs::chia_dialect::{ChiaDialect, ClvmFlags};
 use clvm_rs::cost::Cost;
 use clvm_rs::dialect::{Dialect, OperatorSet};
 use clvm_rs::error::EvalErr;
@@ -23,7 +23,7 @@ use crate::classic::clvm_tools::ir::reader::read_ir;
 use crate::classic::clvm_tools::ir::writer::write_ir_to_stream;
 use crate::classic::clvm_tools::sha256tree::TreeHash;
 use crate::classic::clvm_tools::stages::stage_0::{
-    DefaultProgramRunner, OriginalDialect, RunProgramOption, TRunProgram,
+    choose_run_flags, DefaultProgramRunner, OriginalDialect, RunProgramOption, TRunProgram,
 };
 use crate::classic::clvm_tools::stages::stage_2::compile::do_com_prog_for_dialect;
 use crate::classic::clvm_tools::stages::stage_2::optimize::do_optimize;
@@ -60,6 +60,9 @@ pub struct CompilerOperatorsInternal {
     // The version of the operators selected by the user.  version 1 includes bls.
     operators_version: RefCell<Option<usize>>,
     language_flags: u32,
+    // Since flags have moved into the dialect in clvmr 0.17, they need to move
+    // here too.
+    flags: RefCell<ClvmFlags>,
 }
 
 /// Given a list of search paths, find a full path to a file whose partial name
@@ -151,6 +154,7 @@ impl CompilerOperatorsInternal {
             compiler_opts: RefCell::new(None),
             operators_version: RefCell::new(None),
             language_flags,
+            flags: RefCell::new(ClvmFlags::empty()),
         }
     }
 
@@ -395,6 +399,14 @@ impl Dialect for CompilerOperatorsInternal {
         36
     }
 
+    fn flags(&self) -> ClvmFlags {
+        *self.flags.borrow()
+    }
+
+    fn gc_candidate(&self, _allocator: &Allocator, _node: NodePtr) -> bool {
+        false
+    }
+
     // The softfork operator comes with an extension argument.
     fn softfork_extension(&self, ext: u32) -> OperatorSet {
         match ext {
@@ -416,10 +428,10 @@ impl Dialect for CompilerOperatorsInternal {
             .get_operators_version()
             .unwrap_or(OPERATORS_LATEST_VERSION);
         let base_dialect = if new_operators > 0 {
-            let rc: Box<dyn Dialect> = Box::new(ChiaDialect::new(NO_UNKNOWN_OPS));
+            let rc: Box<dyn Dialect> = Box::new(ChiaDialect::new(ClvmFlags::NO_UNKNOWN_OPS));
             rc
         } else {
-            let rc: Box<dyn Dialect> = Box::new(OriginalDialect::new(NO_UNKNOWN_OPS));
+            let rc: Box<dyn Dialect> = Box::new(OriginalDialect::new(ClvmFlags::NO_UNKNOWN_OPS));
             rc
         };
         // Ensure we have at least the bls extensions available.
@@ -509,14 +521,27 @@ impl TRunProgram for CompilerOperatorsInternal {
         option: Option<RunProgramOption>,
     ) -> Response {
         let max_cost = option.as_ref().and_then(|o| o.max_cost).unwrap_or(0);
-        run_program_with_pre_eval(
+
+        // Flags are a dialect thing now, so we ensure that they're in sync at each stack level.
+        let new_flags = option
+            .as_ref()
+            .map(|o| choose_run_flags(o.operators_version))
+            .unwrap_or(ClvmFlags::NO_UNKNOWN_OPS);
+        let old_flags = *self.flags.borrow();
+        self.flags.replace(new_flags);
+
+        let result = run_program_with_pre_eval(
             allocator,
             self,
             program,
             args,
             max_cost,
             option.and_then(|o| o.pre_eval_f),
-        )
+        );
+
+        // Use the original flags after running.
+        self.flags.replace(old_flags);
+        result
     }
 }
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -82,9 +82,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "cc"
@@ -100,43 +106,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia-bls"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38840e8c8c5c6eb61304d85102230e74c2015c2bfb945292777f83f48915544c"
-dependencies = [
- "blst",
- "chia-sha2 0.28.2",
- "chia-traits 0.28.2",
- "hex",
- "hkdf",
- "linked-hash-map",
- "sha2",
- "thiserror",
-]
-
-[[package]]
-name = "chia-bls"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f02cbfd038d9050d45edbe8f38e09391c73479c0cca5b37925daf48c4d4fcd4"
 dependencies = [
  "blst",
- "chia-sha2 0.36.1",
- "chia-traits 0.36.1",
+ "chia-sha2",
+ "chia-traits",
  "hex",
  "hkdf",
  "linked-hash-map",
  "sha2",
  "thiserror",
-]
-
-[[package]]
-name = "chia-sha2"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f03c71bc63599a711caad15dafca1d2a948c26b4c8a021709a338149632769"
-dependencies = [
- "sha2",
 ]
 
 [[package]]
@@ -150,36 +131,13 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52463c56cdf35aac55ecb35ffc0a615f0780f33f144503957e83f5b1ad92da3c"
-dependencies = [
- "chia-sha2 0.28.2",
- "chia_streamable_macro 0.28.2",
- "thiserror",
-]
-
-[[package]]
-name = "chia-traits"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4922b447b2d8418213948af1a448c3ca7b84e149b51b2c87a2e00e80bb19b0"
 dependencies = [
- "chia-sha2 0.36.1",
- "chia_streamable_macro 0.36.1",
+ "chia-sha2",
+ "chia_streamable_macro",
  "thiserror",
-]
-
-[[package]]
-name = "chia_streamable_macro"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b807a9c04440d3f30b5534b84b462b996b34eee7fe0b7f8737ae6dfc6b9d4"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -199,7 +157,7 @@ name = "chialisp"
 version = "0.4.3"
 dependencies = [
  "binascii",
- "chia-bls 0.36.1",
+ "chia-bls",
  "clvmr",
  "do-notation",
  "getrandom 0.2.15",
@@ -237,18 +195,20 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.16.2"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf14f44f7c6b1d7972753cdd66f6afae38b117b752e6d1256b6f532dc3a0d304"
+checksum = "56b333963b083468df9a15602fcc3a24fa3f8c3964569fb9d2415ac70c0820e9"
 dependencies = [
+ "bitflags",
  "bitvec",
  "bumpalo",
- "chia-bls 0.28.2",
- "chia-sha2 0.28.2",
+ "chia-bls",
+ "chia-sha2",
  "hex",
  "hex-literal",
  "k256",
  "lazy_static",
+ "malachite-bigint",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -338,6 +298,12 @@ dependencies = [
  "signature",
  "spki",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -542,6 +508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +608,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83e5106554cabc97552dcadf54f57560ae6af3276652f82ca2be06120dc4c5dc"
 dependencies = [
  "spin",
+]
+
+[[package]]
+name = "malachite-base"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b6f86fdbb1eb9955946be91775239dfcb0acdb1a51bb07d5fc9b8c854f5ccd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "itertools",
+ "libm",
+ "ryu",
+]
+
+[[package]]
+name = "malachite-bigint"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fcd6e504ffc67db2b3c6d5e90e08054646e2b04f42115a5460bf1c1e37d3bc"
+dependencies = [
+ "malachite-base",
+ "malachite-nz",
+ "num-integer",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0197a2f5cfee19d59178e282985c6ca79a9233e26a2adcf40acb693896aa09f6"
+dependencies = [
+ "itertools",
+ "libm",
+ "malachite-base",
+ "wide",
 ]
 
 [[package]]
@@ -736,6 +754,12 @@ dependencies = [
  "primeorder",
  "sha2",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -905,9 +929,18 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1206,6 +1239,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wide"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/mod.rs"
 
 [dependencies]
 chialisp = { path= "..", features = [] }
-clvmr = { version = "0.16.0", features = ["pre-eval"] }
+clvmr = { version = "0.17.5", features = ["pre-eval"] }
 wasm-bindgen = "=0.2.100"
 js-sys = "0.3.60"
 num-bigint = "0.4.0"

--- a/wasm/rust-toolchain.toml
+++ b/wasm/rust-toolchain.toml
@@ -1,5 +1,5 @@
 
 [toolchain]
-channel = "stable-2025-08-07"
+channel = "1.94.1"
 components = [ "rustfmt", "rustc", "rust-std", "rust-analyzer", "rustc-dev" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates a core execution dependency (`clvmr`) and adapts dialect/flag handling, which could subtly change CLVM evaluation behavior across operator versions. Also pins CI/toolchains, so build failures are possible if the repo relied on newer `stable` behavior.
> 
> **Overview**
> Upgrades the `clvmr` dependency to `0.17.5` (including lockfile updates for new/transitive crates) for both the main crate and the WASM build.
> 
> Refactors classic runner/dialect integration to match `clvmr`’s new `ClvmFlags` API: introduces `choose_run_flags`, stores flags on `CompilerOperatorsInternal`, threads flags through dialect ops, and ensures flags are restored after nested `run_program` calls.
> 
> Pins Rust toolchains to `1.94.1` across `rust-toolchain.toml`, `wasm/rust-toolchain.toml`, and GitHub Actions workflows to keep builds consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd9d9aca2871869c06faa8074df98c79d949f60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->