### PR TITLE
Ensure ARM JIT DWARF subprograms consistently use pointer return type

### DIFF
--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1050,40 +1050,53 @@ impl DwarfBuilder {
         // at from, then decorate all of them with the argument retriever below.
 
         eprintln!("get subprogram");
-        let subprogram_id = {
+        let mut subprogram_names = vec![name.clone()];
+        if name != label {
+            // Keep a typed DIE for both the colloquial and emitted symbol names so
+            // either one resolves to the same pointer return type in debuggers.
+            subprogram_names.push(label.to_string());
+        }
+        let subprogram_ids = {
             let unit = self.dwarf.units.get_mut(self.unit_id);
-            let subprogram_id = unit.add(unit.root(), DW_TAG_subprogram);
+            let mut subprogram_ids = Vec::with_capacity(subprogram_names.len());
+            for subprogram_name in subprogram_names.iter() {
+                let subprogram_id = unit.add(unit.root(), DW_TAG_subprogram);
 
-            // Frame pointer for the function.
-            let mut fbexpr_mid = Expression::new();
-            fbexpr_mid.op_breg(gimli::Register(13), 0);
-            let mut loclist = Vec::new();
-            loclist.push(Location::StartEnd {
-                begin: Address::Constant(addr as u64),
-                end: Address::Constant((addr + size) as u64),
-                data: fbexpr_mid,
-            });
-            let loc_list_id = unit.locations.add(LocationList(loclist));
-            let mut sub_ent = unit.get_mut(subprogram_id);
-            sub_ent.set(DW_AT_name, AttributeValue::String(name.as_bytes().to_vec()));
-            sub_ent.set(DW_AT_type, AttributeValue::UnitRef(self.pointer_type));
-            sub_ent.set(
-                DW_AT_low_pc,
-                AttributeValue::Address(Address::Constant(
-                    (self.target_addr as usize + addr) as u64,
-                )),
-            );
-            sub_ent.set(
-                DW_AT_high_pc,
-                AttributeValue::Address(Address::Constant(
-                    (self.target_addr as usize + addr + size) as u64,
-                )),
-            );
-            sub_ent.set(
-                DW_AT_frame_base,
-                AttributeValue::LocationListRef(loc_list_id),
-            );
-            subprogram_id
+                // Frame pointer for the function.
+                let mut fbexpr_mid = Expression::new();
+                fbexpr_mid.op_breg(gimli::Register(13), 0);
+                let mut loclist = Vec::new();
+                loclist.push(Location::StartEnd {
+                    begin: Address::Constant(addr as u64),
+                    end: Address::Constant((addr + size) as u64),
+                    data: fbexpr_mid,
+                });
+                let loc_list_id = unit.locations.add(LocationList(loclist));
+                let mut sub_ent = unit.get_mut(subprogram_id);
+                sub_ent.set(
+                    DW_AT_name,
+                    AttributeValue::String(subprogram_name.as_bytes().to_vec()),
+                );
+                sub_ent.set(DW_AT_type, AttributeValue::UnitRef(self.pointer_type));
+                sub_ent.set(
+                    DW_AT_low_pc,
+                    AttributeValue::Address(Address::Constant(
+                        (self.target_addr as usize + addr) as u64,
+                    )),
+                );
+                sub_ent.set(
+                    DW_AT_high_pc,
+                    AttributeValue::Address(Address::Constant(
+                        (self.target_addr as usize + addr + size) as u64,
+                    )),
+                );
+                sub_ent.set(
+                    DW_AT_frame_base,
+                    AttributeValue::LocationListRef(loc_list_id),
+                );
+                subprogram_ids.push(subprogram_id);
+            }
+            subprogram_ids
         };
         eprintln!("about to parse args");
         let srcloc = Srcloc::start("*args*");
@@ -1119,13 +1132,15 @@ impl DwarfBuilder {
                 },
             ];
             if !parsed.is_empty() {
-                self.add_arguments(
-                    subprogram_id,
-                    &locations,
-                    bi_one(),
-                    bi_zero(),
-                    parsed[0].clone(),
-                );
+                for subprogram_id in subprogram_ids.iter().copied() {
+                    self.add_arguments(
+                        subprogram_id,
+                        &locations,
+                        bi_one(),
+                        bi_zero(),
+                        parsed[0].clone(),
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `DwarfBuilder::decorate_function` to emit typed `DW_TAG_subprogram` entries for both the human-readable function name and the emitted symbol label when they differ
- ensure each generated subprogram DIE has `DW_AT_type = self.pointer_type`
- attach the same argument/location metadata to each emitted subprogram DIE so debugger lookups through either name see consistent return/parameter typing

## Why
Some symbols are emitted under internal labels while debug names are mapped to colloquial names. Emitting typed DIEs for both names makes debugger resolution consistent and ensures all functions appear to return `self.pointer_type`.

## Testing
- not yet run in this pre-testing revision (follow-up validation planned)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a44e938-97c9-4c60-98dc-9ce4d493a6c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a44e938-97c9-4c60-98dc-9ce4d493a6c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

