### PR TITLE
Try Removing added atomize calls.  I am admittedly hazy on why i adde…

### DIFF
--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -655,7 +655,7 @@ fn match_op_name_4(pl: &[SExp]) -> Option<OpName4Match> {
     // a bit more forgiving when we're examining code that has round-tripped through traditional
     // clvm, which happens when modern tools such as use check are used on classic programs.
     // The modern frontend requires atom representation in positions 0 and 1 of helpers anyway.
-    match &pl[0].atomize() {
+    match &pl[0] {
         SExp::Atom(l, op_name) => {
             if pl.len() < 3 {
                 return Some(OpName4Match {
@@ -669,7 +669,7 @@ fn match_op_name_4(pl: &[SExp]) -> Option<OpName4Match> {
                 });
             }
 
-            match &pl[1].atomize() {
+            match &pl[1] {
                 SExp::Atom(ll, name) => {
                     let tail_idx = 3;
                     let mut tail_list = Vec::new();


### PR DESCRIPTION
…d these (probably defensiveness).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes helper-form parsing to require `SExp::Atom` in positions 0 and 1 (no implicit `atomize()`), which could reject previously accepted round-tripped/non-strict inputs and surface new compile errors.
> 
> **Overview**
> Removes the defensive `atomize()` calls in `match_op_name_4` when matching helper forms, so the frontend now matches helper keywords and names only when `pl[0]`/`pl[1]` are already `SExp::Atom`.
> 
> This tightens parsing behavior for helper definitions (e.g., `defun`, `defconst`, `defmacro`, `namespace`, `import`) and may change how non-atom encodings in those positions are handled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9fbadb36fc71717636f65b374450c343f155df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->