### PR TITLE
armjit: hash alias fallback for renamed JIT symbols

### DIFF
--- a/src/compiler/debug/armjit/cmd.rs
+++ b/src/compiler/debug/armjit/cmd.rs
@@ -99,38 +99,41 @@ pub fn compile_to_arm_elf(args: &Args) -> Result<(Vec<u8>, HashMap<String, Strin
 
     let opts = DefaultCompilerOpts::new(&args.filename).set_search_paths(&parsed.search_paths);
 
-    let (program_locations, compiled) =
-        if parsed.dialect.stepping.is_some() {
-            let parsed_program = parse_sexp(Srcloc::start(&args.filename), argfile.bytes()).map_err(|e| format!("failed to parse chialisp program {}", args.filename))?;
-            let fe = frontend(parsed.opts.clone(), &parsed_program).map_err(|e| format!("failed to compose frontend program"))?;
-            let compiled = compile_file(&mut allocator, runner, opts, &argfile, &mut symbol_table)
-                .map_err(|e| format!("failed to compile chialisp: {e:?}"))?;
-            build_symbol_table_mut(&mut symbol_table, &compiled);
-            eprintln!("compiled {compiled}");
-            let range_results: HashMap<String, Srcloc> = fe.helpers.iter().map(|h| {
-                (decode_string(h.name()), h.loc())
-            }).collect();
-            (range_results, Rc::new(compiled))
-        } else {
-            let compile_invoke_code = run(&mut allocator);
-            let assembled_sexp = assemble(&mut allocator, &argfile)
-                .map_err(|e| format!("failed to assemble clvm {e:?}"))?;
-            let input_sexp = allocator
-                .new_pair(assembled_sexp, NodePtr::NIL)
-                .map_err(|e| format!("failed to allocate compiler args {e:?}"))?;
-            special_runner.set_compiler_opts(Some(opts));
-            let run_program_output = special_runner
-                .run_program(&mut allocator, compile_invoke_code, input_sexp, None)
-                .map_err(|e| format!("failed to run classic compiler: {e:?}"))?;
-            symbol_table = special_runner.get_compiles();
-            let compiled = convert_from_clvm_rs(
-                &mut allocator,
-                Srcloc::start(&args.filename),
-                run_program_output.1,
-            )
-                .map_err(|e| format!("failed to convert clvm {e:?}"))?;
-            (HashMap::new(), compiled)
-        };
+    let (program_locations, compiled) = if parsed.dialect.stepping.is_some() {
+        let parsed_program = parse_sexp(Srcloc::start(&args.filename), argfile.bytes())
+            .map_err(|e| format!("failed to parse chialisp program {}", args.filename))?;
+        let fe = frontend(parsed.opts.clone(), &parsed_program)
+            .map_err(|e| format!("failed to compose frontend program"))?;
+        let compiled = compile_file(&mut allocator, runner, opts, &argfile, &mut symbol_table)
+            .map_err(|e| format!("failed to compile chialisp: {e:?}"))?;
+        build_symbol_table_mut(&mut symbol_table, &compiled);
+        eprintln!("compiled {compiled}");
+        let range_results: HashMap<String, Srcloc> = fe
+            .helpers
+            .iter()
+            .map(|h| (decode_string(h.name()), h.loc()))
+            .collect();
+        (range_results, Rc::new(compiled))
+    } else {
+        let compile_invoke_code = run(&mut allocator);
+        let assembled_sexp = assemble(&mut allocator, &argfile)
+            .map_err(|e| format!("failed to assemble clvm {e:?}"))?;
+        let input_sexp = allocator
+            .new_pair(assembled_sexp, NodePtr::NIL)
+            .map_err(|e| format!("failed to allocate compiler args {e:?}"))?;
+        special_runner.set_compiler_opts(Some(opts));
+        let run_program_output = special_runner
+            .run_program(&mut allocator, compile_invoke_code, input_sexp, None)
+            .map_err(|e| format!("failed to run classic compiler: {e:?}"))?;
+        symbol_table = special_runner.get_compiles();
+        let compiled = convert_from_clvm_rs(
+            &mut allocator,
+            Srcloc::start(&args.filename),
+            run_program_output.1,
+        )
+        .map_err(|e| format!("failed to convert clvm {e:?}"))?;
+        (HashMap::new(), compiled)
+    };
 
     let env_node =
         assemble(&mut allocator, &args.env).map_err(|e| format!("failed to read env: {e:?}"))?;

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -2233,7 +2233,8 @@ impl Program {
             p.remap_locations
                 .insert(remap_hash_hex.clone(), remap_sexp.loc());
             p.add_sexp(&remap_sexp.loc(), &remap_hash, remap_sexp.clone());
-            p.add(remap_sexp);
+            let remap_label = p.add(remap_sexp);
+            eprintln!("remap selected label {remap_label} for {name}");
         }
         p.first_label = p.add(sexp.clone());
         p.start_insns();

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1334,7 +1334,9 @@ impl Program {
     }
 
     fn label_is_taken(&self, label: &str) -> bool {
-        self.labels_by_hash.values().any(|existing| existing == label)
+        self.labels_by_hash
+            .values()
+            .any(|existing| existing == label)
     }
 
     fn get_program_function_label(&self, sexp: Rc<SExp>) -> Option<String> {
@@ -2229,7 +2231,8 @@ impl Program {
         for (remap_hash, name, remap_sexp) in remap_hashes.into_iter() {
             let remap_hash_hex = hex::encode(&remap_hash);
             eprintln!("should remap hash {} to {name}", remap_hash_hex);
-            p.renamed_symbols.insert(remap_hash_hex.clone(), name.clone());
+            p.renamed_symbols
+                .insert(remap_hash_hex.clone(), name.clone());
             p.remap_locations
                 .insert(remap_hash_hex.clone(), remap_sexp.loc());
             p.add_sexp(&remap_sexp.loc(), &remap_hash, remap_sexp.clone());

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1012,7 +1012,13 @@ impl DwarfBuilder {
     }
 
     // Create dwarf traffic needed to ensure that gdb can find the locals.
-    fn decorate_function(&mut self, label: &str, addr: usize, size: usize) -> Option<String> {
+    fn decorate_function(
+        &mut self,
+        label: &str,
+        addr: usize,
+        size: usize,
+        preferred_name: Option<&str>,
+    ) -> Option<String> {
         let mut fde = FrameDescriptionEntry::new(
             Address::Constant((self.target_addr as usize + addr) as u64),
             size as u32,
@@ -1044,10 +1050,13 @@ impl DwarfBuilder {
             .expect("CFI CIE should be initialized for unwind info");
         self.frame_table.add_fde(cfi_cie_id, fde);
 
-        let (name, args) = self
-            .match_function(&label)
-            .map(|c| c.clone())
-            .unwrap_or_else(|| (label.to_string(), "ENV".to_string()));
+        let (name, args) = if let Some(preferred_name) = preferred_name {
+            (preferred_name.to_string(), "ENV".to_string())
+        } else {
+            self.match_function(&label)
+                .map(|c| c.clone())
+                .unwrap_or_else(|| (label.to_string(), "ENV".to_string()))
+        };
 
         // We'll make 3 subprograms to represent where the current arguments can be arrived
         // at from, then decorate all of them with the argument retriever below.
@@ -1221,8 +1230,10 @@ pub struct Program {
     constants: HashMap<Vec<u8>, Constant>,
     symbol_table: Rc<HashMap<String, String>>,
     current_symbol: Option<String>,
+    current_symbol_name: Option<String>,
     function_symbols: HashMap<String, String>,
     renamed_symbols: HashMap<String, String>,
+    remap_locations: HashMap<String, Srcloc>,
     start_addr: usize,
     current_addr: usize,
     dwarf_builder: DwarfBuilder,
@@ -1282,33 +1293,32 @@ pub fn swi_print(register: usize, label: usize) -> usize {
     SWI_PRINT_EXPR | register << 4 | label << 8
 }
 
-fn find_by_hash(hash: &[u8], sexp: Rc<SExp>) -> (Vec<u8>, Option<Rc<SExp>>) {
+fn collect_by_hash(hash: &[u8], sexp: Rc<SExp>, matches: &mut Vec<Rc<SExp>>) -> Vec<u8> {
     if let SExp::Cons(_, a, b) = &*sexp {
-        let (mut hash_a, found_a) = find_by_hash(hash, a.clone());
-        if let Some(ref fh) = found_a {
-            return (hash_a, found_a);
-        }
-        let (mut hash_b, found_b) = find_by_hash(hash, b.clone());
-        if let Some(ref fh) = found_b {
-            return (hash_b, found_b);
-        }
+        let hash_a = collect_by_hash(hash, a.clone(), matches);
+        let hash_b = collect_by_hash(hash, b.clone(), matches);
         let mut hasher = Sha256::new();
         hasher.update([2]);
         hasher.update(&hash_a);
         hasher.update(&hash_b);
         let my_hash = hasher.finalize().to_vec();
         if my_hash == hash {
-            return (my_hash, Some(sexp.clone()));
+            matches.push(sexp);
         }
-        (my_hash, None)
+        my_hash
     } else {
         let the_hash = sha256tree(sexp.clone());
         if the_hash == hash {
-            (the_hash, Some(sexp.clone()))
-        } else {
-            (the_hash, None)
+            matches.push(sexp);
         }
+        the_hash
     }
+}
+
+fn find_all_by_hash(hash: &[u8], sexp: Rc<SExp>) -> Vec<Rc<SExp>> {
+    let mut matches = Vec::new();
+    collect_by_hash(hash, sexp, &mut matches);
+    matches
 }
 
 struct Function {
@@ -1318,6 +1328,37 @@ struct Function {
 }
 
 impl Program {
+    fn get_renamed_function_label(&self, hash: &[u8]) -> Option<String> {
+        let hash_string = hex::encode(hash);
+        self.renamed_symbols.get(&hash_string).cloned()
+    }
+
+    fn label_is_taken(&self, label: &str) -> bool {
+        self.labels_by_hash.values().any(|existing| existing == label)
+    }
+
+    fn get_program_function_label(&self, sexp: Rc<SExp>) -> Option<String> {
+        let target_loc = sexp.loc();
+        let hash = sha256tree(sexp.clone());
+        let hash_hex = hex::encode(&hash);
+        if let Some(remap_loc) = self.remap_locations.get(&hash_hex) {
+            if remap_loc == &target_loc {
+                if let Some(name) = self.renamed_symbols.get(&hash_hex) {
+                    return Some(name.clone());
+                }
+            }
+        }
+        self.program
+            .iter()
+            .find(|(_name, loc)| loc.overlap(&target_loc))
+            .map(|(name, _loc)| name.clone())
+    }
+
+    fn get_renamed_name_for_label(&self, label: &str) -> Option<String> {
+        let hash = label.strip_prefix('_').and_then(|s| s.split('_').next())?;
+        self.renamed_symbols.get(hash).cloned()
+    }
+
     fn get_code_label(&mut self, hash: &[u8]) -> String {
         let n = if let Some(n) = self.encounters_of_code.get(hash).clone() {
             *n
@@ -1660,25 +1701,20 @@ impl Program {
 
     fn add(&mut self, sexp: Rc<SExp>) -> String {
         let hash = sha256tree(sexp.clone());
+        if let Some(existing_label) = self.labels_by_hash.get(&hash) {
+            return existing_label.clone();
+        }
 
         // Note: get_code_label issues a fresh label for this hash every time.
-        let body_label = self.get_code_label(&hash);
+        let generated_body_label = self.get_code_label(&hash);
+        let body_label = self
+            .get_renamed_function_label(&hash)
+            .or_else(|| self.get_program_function_label(sexp.clone()))
+            .filter(|label| !self.label_is_taken(label))
+            .unwrap_or(generated_body_label);
         eprintln!("label {body_label} for {sexp} at {}", sexp.loc());
 
-        let body_label =
-            if let Some(new_name) = self.program.iter().find(|(name, loc)| {
-                loc.overlap(&sexp.loc())
-            }).map(|(name, _)| name.clone()) {
-                if !self.renamed_symbols.contains_key(&new_name) {
-                    self.renamed_symbols.insert(new_name.clone(), body_label.clone());
-                    new_name
-                } else {
-                    body_label
-                }
-            } else {
-                body_label
-            };
-
+        self.labels_by_hash.insert(hash, body_label.clone());
         self.waiting_programs
             .push((body_label.clone(), sexp.clone()));
         body_label
@@ -1700,6 +1736,7 @@ impl Program {
             //
             // Ensure we set the current symbol.
             self.current_symbol = Some(g.clone());
+            self.current_symbol_name = self.get_renamed_name_for_label(g);
 
             instr
         } else {
@@ -1722,15 +1759,18 @@ impl Program {
                     "end block for label {label} {:x}-{:x}",
                     self.start_addr, self.current_addr
                 );
+                let preferred_name = self.current_symbol_name.clone();
                 if let Some(function_name) = self.dwarf_builder.decorate_function(
                     label,
                     self.start_addr,
                     self.current_addr - self.start_addr,
+                    preferred_name.as_deref(),
                 ) {
                     eprintln!("end block with function {function_name}");
                     self.function_symbols.insert(label.clone(), function_name);
                 }
                 self.current_symbol = None;
+                self.current_symbol_name = None;
             }
         }
 
@@ -1907,6 +1947,28 @@ impl Program {
         }
         swap(&mut constants, &mut self.constants);
 
+        // Export remapped function names by hash so the emulator can resolve
+        // a tree hash to a renamed symbol after loading the ELF.
+        let mut renamed_symbols: Vec<_> = self
+            .renamed_symbols
+            .iter()
+            .map(|(hash, target_name)| (hash.clone(), target_name.clone()))
+            .collect();
+        renamed_symbols.sort_by(|a, b| a.0.cmp(&b.0));
+        for (hash, target_name) in renamed_symbols.into_iter() {
+            let mut target_name_bytes = target_name.as_bytes().to_vec();
+            target_name_bytes.push(0);
+            let remap_label = format!("_$_{hash}");
+            for i in &[
+                Instr::Align4,
+                Instr::Globl(remap_label.clone()),
+                Instr::Label(remap_label),
+                Instr::Bytes(target_name_bytes.clone()),
+            ] {
+                self.push(source_sexp.clone(), &srcloc, i.clone());
+            }
+        }
+
         self.dwarf_builder
             .write(self.current_addr, &mut self.finished_insns)
             .unwrap();
@@ -1967,7 +2029,9 @@ impl Program {
 
         // Declare functions as imports and later link the labels they belong to.
         for (label, funname) in self.function_symbols.iter() {
-            decls.push((funname.clone(), Decl::function().into()));
+            if label != funname {
+                decls.push((funname.clone(), Decl::function().into()));
+            }
         }
 
         // Declare .debug_aranges
@@ -1993,7 +2057,7 @@ impl Program {
             if let Some(defname) = in_function.as_ref() {
                 if !function_body.is_empty() {
                     if let Some(funname) = self.function_symbols.get(defname) {
-                        if !defined_colloquial_names.contains(funname) {
+                        if funname != defname && !defined_colloquial_names.contains(funname) {
                             obj.define(funname, vec![]).map_err(|e| format!("{e:?}"))?;
                             defined_colloquial_names.insert(funname.clone());
                         }
@@ -2106,6 +2170,35 @@ impl Program {
         target_addr: u32,
         symbol_table: Rc<HashMap<String, String>>,
     ) -> Result<Self, String> {
+        let remap_hashes: Vec<_> = symbol_table
+            .iter()
+            .filter_map(|(hash, name)| {
+                if name.contains(':') || name.contains('_') || name == "source_file" {
+                    return None;
+                }
+                if !program.contains_key(name) {
+                    return None;
+                }
+
+                if let Ok(byte_hash) = hex::decode(hash) {
+                    let all_matches = find_all_by_hash(&byte_hash, sexp.clone());
+                    let selected = if let Some(target_loc) = program.get(name) {
+                        all_matches
+                            .iter()
+                            .find(|matched| target_loc.overlap(&matched.loc()))
+                            .cloned()
+                    } else {
+                        None
+                    }
+                    .or_else(|| all_matches.first().cloned());
+                    if let Some(selected) = selected {
+                        return Some((byte_hash, name.clone(), selected));
+                    }
+                }
+                None
+            })
+            .collect();
+
         let dwarf_builder =
             DwarfBuilder::new(filename, elf_output, target_addr, symbol_table.clone());
         let mut p: Program = Program {
@@ -2121,36 +2214,29 @@ impl Program {
             symbol_table: Default::default(),
             function_symbols: Default::default(),
             renamed_symbols: Default::default(),
+            remap_locations: Default::default(),
             current_addr: 0,
             start_addr: 0,
             target_addr,
             current_symbol: None,
+            current_symbol_name: None,
             dwarf_builder,
         };
 
         p.symbol_table = symbol_table;
         let loc = Srcloc::start("*env*");
         let envhash = sha256tree(env.clone());
+        for (remap_hash, name, remap_sexp) in remap_hashes.into_iter() {
+            let remap_hash_hex = hex::encode(&remap_hash);
+            eprintln!("should remap hash {} to {name}", remap_hash_hex);
+            p.renamed_symbols.insert(remap_hash_hex.clone(), name.clone());
+            p.remap_locations
+                .insert(remap_hash_hex.clone(), remap_sexp.loc());
+            p.add_sexp(&remap_sexp.loc(), &remap_hash, remap_sexp.clone());
+            p.add(remap_sexp);
+        }
         p.first_label = p.add(sexp.clone());
         p.start_insns();
-        let remap_hashes: Vec<_> = p.symbol_table.iter().filter_map(|(hash, name)| {
-            if name.contains(':') {
-                return None;
-            }
-
-            if let Ok(byte_hash) = hex::decode(&hash) {
-                if let (remap_hash, Some(sexp)) = find_by_hash(&byte_hash, sexp.clone()) {
-                    return Some((remap_hash, name.clone(), sexp.clone()));
-                }
-            }
-            None
-        }).collect();
-
-        for (remap_hash, name, sexp) in remap_hashes.into_iter() {
-            eprintln!("should remap hash {} to {name}", hex::encode(&remap_hash));
-            p.renamed_symbols.insert(hex::encode(&remap_hash), name.clone());
-            p.add_sexp(&sexp.loc(), &remap_hash, sexp.clone());
-        }
         p.env_label = p.add_sexp(&loc, &envhash, env);
         p.emit_waiting();
         p.finish_insns()?;

--- a/src/compiler/debug/armjit/emu.rs
+++ b/src/compiler/debug/armjit/emu.rs
@@ -298,6 +298,40 @@ fn match_printing(operator: Rc<SExp>, sexp: Rc<SExp>) -> Option<Rc<SExp>> {
 }
 
 impl Emu {
+    fn get_nul_terminated_string(&self, addr: u32) -> Option<String> {
+        if addr == 0 {
+            return None;
+        }
+
+        let mut out = Vec::new();
+        for i in 0..1024_u32 {
+            let b = self.mem.read_u8(addr + i);
+            if b == 0 {
+                return Some(String::from_utf8_lossy(&out).to_string());
+            }
+            out.push(b);
+        }
+
+        None
+    }
+
+    fn lookup_dispatch_target_by_hash(&self, hash_hex: &str) -> Option<u32> {
+        if let Some(lookup) = self.jit_symbols.get(hash_hex) {
+            return Some(lookup.address);
+        }
+
+        let alias_symbol = format!("_$_{hash_hex}");
+        if let Some(alias_info) = self.jit_symbols.get(&alias_symbol) {
+            if let Some(alias_name) = self.get_nul_terminated_string(alias_info.address) {
+                if let Some(lookup) = self.jit_symbols.get(&alias_name) {
+                    return Some(lookup.address);
+                }
+            }
+        }
+
+        None
+    }
+
     pub fn new(
         program_elf: &[u8],
         start_addr: u32,
@@ -477,13 +511,13 @@ impl Emu {
             // Setup stack frame in code buffer.
 
             let current_pc = self.cpu.reg_get(Mode::User, reg::PC);
-            if let Some(lookup) = self.jit_symbols.get(&string_of_hash) {
+            if let Some(dispatch_address) = self.lookup_dispatch_target_by_hash(&string_of_hash) {
                 // We found it, transfer control.
                 self.cpu
                     .reg_set(Mode::User, 0, self.cpu.reg_get(Mode::User, 7));
                 self.cpu.reg_set(Mode::User, reg::LR, current_pc + 8);
                 self.cpu.reg_set(Mode::User, reg::PC, current_pc + 4);
-                self.cpu.reg_set(Mode::User, 1, lookup.address);
+                self.cpu.reg_set(Mode::User, 1, dispatch_address);
                 return None;
             };
 

--- a/src/compiler/debug/armjit/emu.rs
+++ b/src/compiler/debug/armjit/emu.rs
@@ -43,9 +43,9 @@ use crate::compiler::dialect::AcceptedDialect;
 #[cfg(test)]
 use crate::compiler::frontend::frontend;
 use crate::compiler::prims::primquote;
-use crate::compiler::sexp::{parse_sexp, SExp};
 #[cfg(test)]
 use crate::compiler::sexp::decode_string;
+use crate::compiler::sexp::{parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
 use crate::compiler::TRunProgram;
 
@@ -908,11 +908,15 @@ impl Emu {
             .set_search_paths(&search_paths)
             .set_frontend_opt(false);
 
-        let parsed_program = parse_sexp(srcloc.clone(), program.bytes()).map_err(|e| format!("failed to parse chialisp program {filename}"))?;
-        let fe = frontend(opts.clone(), &parsed_program).map_err(|e| format!("failed to compose frontend program"))?;
-        let range_results: HashMap<String, Srcloc> = fe.helpers.iter().map(|h| {
-            (decode_string(h.name()), h.loc())
-        }).collect();
+        let parsed_program = parse_sexp(srcloc.clone(), program.bytes())
+            .map_err(|e| format!("failed to parse chialisp program {filename}"))?;
+        let fe = frontend(opts.clone(), &parsed_program)
+            .map_err(|e| format!("failed to compose frontend program"))?;
+        let range_results: HashMap<String, Srcloc> = fe
+            .helpers
+            .iter()
+            .map(|h| (decode_string(h.name()), h.loc()))
+            .collect();
 
         let compiled = compile_file(&mut allocator, runner, opts, program, &mut symbol_table)
             .expect("should compile");
@@ -921,7 +925,7 @@ impl Emu {
         let tmpname = tmpfile.path().to_str().unwrap().to_string();
         let symbols = Rc::new(symbol_table);
         let generator = Program::new(
-	    range_results,            
+            range_results,
             filename,
             &tmpname,
             Rc::new(compiled),

--- a/src/compiler/debug/armjit/load.rs
+++ b/src/compiler/debug/armjit/load.rs
@@ -310,12 +310,20 @@ impl<'a> ElfLoader<'a> {
             let mut result = HashMap::new();
             for es in self.symbols.iter() {
                 let sym_string = get_string(es.st_name);
+                let raw = decode_string(&sym_string);
+                if raw.is_empty() {
+                    continue;
+                }
                 if let Some(target_section) = self.elf.section_header_nth(es.st_shndx as usize) {
+                    let sym_info = EmuSymbolInfo {
+                        stripped: raw.clone(),
+                        raw: raw.clone(),
+                        address: self.sections[es.st_shndx as usize] + es.st_value,
+                    };
                     if target_section
                         .flags()
                         .contains(SectionHeaderFlags::SHF_EXECINSTR)
                     {
-                        let raw = decode_string(&sym_string);
                         let stripped = if let Some(stripped) =
                             raw.strip_prefix('_').and_then(|s| s.split('_').next())
                         {
@@ -323,13 +331,13 @@ impl<'a> ElfLoader<'a> {
                         } else {
                             raw.clone()
                         };
-                        let sym_info = EmuSymbolInfo {
-                            stripped: stripped.clone(),
-                            raw: raw.clone(),
-                            address: self.sections[es.st_shndx as usize] + es.st_value,
-                        };
-                        result.insert(raw, sym_info.clone());
-                        result.insert(stripped, sym_info);
+                        let mut function_sym_info = sym_info.clone();
+                        function_sym_info.stripped = stripped.clone();
+                        result.insert(raw, function_sym_info.clone());
+                        result.insert(stripped, function_sym_info);
+                    } else if raw.starts_with("_$_") {
+                        // Hash -> renamed function alias data entries.
+                        result.insert(raw, sym_info);
                     }
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update armjit code generation to keep hash->symbol remaps explicit and stable, and emit `_$_{hash}` NUL-terminated alias data objects in ELF `.data`
- extend ELF symbol loading so emulator symbol lookup can see non-exec `_$_...` alias objects
- add emulator SWI dispatch fallback: when direct hash lookup misses, read `_$_{hash}` from emulated memory, resolve the renamed function symbol, and branch there

## Details
- `Program::new` now collects remap candidates once from the symbol table and source overlaps, filters to real helper names, and seeds remap metadata before code emission
- `Program::add` now memoizes label-by-hash and can choose remapped names consistently, while preserving generated labels when names are already taken
- `DwarfBuilder::decorate_function` accepts an optional preferred function name for emitted symbol/DWARF name alignment where available
- `.to_elf` avoids duplicate faerie defines for colloquial names when label and decorated function name are identical, and emits alias data symbols `_$_{hash}` with NUL-terminated target names
- `Emu` gains `lookup_dispatch_target_by_hash` and `get_nul_terminated_string` for remap-aware SWI dispatch

## Validation
- `cargo test test_compile_and_run_apply_function_1 -- --nocapture`
- `cargo test test_compile_and_run_apply_function_0 -- --nocapture`
- built mandelbrot ELF and verified `_$_{hash}` alias payloads for target functions using `readelf -x`:
  - `_$_46f1...` => `scan\0`
  - `_$_2fd4...` => `basic-scanline\0`
  - `_$_5dad...` => `escape-steps\0`
- ran emulator+gdb session and observed repeated debug output events plus final program output in the remote run (`(result ||5A|7E)`), with hash-symbol breakpoints and alias-resolution path active
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdd86ea8-97f0-4334-8d70-f0f3e22b3f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdd86ea8-97f0-4334-8d70-f0f3e22b3f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

