### PR TITLE
Preserve DWARF arguments for renamed Mandelbrot functions

### DIFF
--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1050,13 +1050,15 @@ impl DwarfBuilder {
             .expect("CFI CIE should be initialized for unwind info");
         self.frame_table.add_fde(cfi_cie_id, fde);
 
-        let (name, args) = if let Some(preferred_name) = preferred_name {
-            (preferred_name.to_string(), "ENV".to_string())
-        } else {
-            self.match_function(&label)
-                .map(|c| c.clone())
-                .unwrap_or_else(|| (label.to_string(), "ENV".to_string()))
-        };
+        let matched_signature = self.match_function(&label);
+        let name = preferred_name
+            .map(str::to_string)
+            .or_else(|| matched_signature.as_ref().map(|(name, _)| name.clone()))
+            .unwrap_or_else(|| label.to_string());
+        let args = matched_signature
+            .as_ref()
+            .map(|(_, args)| args.clone())
+            .unwrap_or_else(|| "ENV".to_string());
 
         // We'll make 3 subprograms to represent where the current arguments can be arrived
         // at from, then decorate all of them with the argument retriever below.

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -901,8 +901,33 @@ impl DwarfBuilder {
     }
 
     fn match_function(&self, label: &str) -> Option<(String, String)> {
-        let mut stripped: Vec<u8> = label.bytes().skip(1).take_while(|b| *b != b'_').collect();
-        if let Some(name) = self.symbol_table.get(&decode_string(&stripped)).cloned() {
+        let symbol_hash = if let Some(stripped) = label.strip_prefix('_') {
+            let hash = stripped
+                .chars()
+                .take_while(|c| *c != '_')
+                .collect::<String>();
+            if self.symbol_table.contains_key(&hash) {
+                Some(hash)
+            } else {
+                None
+            }
+        } else {
+            self.symbol_table
+                .iter()
+                .find(|(hash, name)| {
+                    *name == label
+                        && hash.len() == 64
+                        && hash.as_bytes().iter().all(|b| b.is_ascii_hexdigit())
+                })
+                .map(|(hash, _)| hash.clone())
+        };
+        if let Some(symbol_hash) = symbol_hash {
+            let mut stripped = symbol_hash.as_bytes().to_vec();
+            let name = self
+                .symbol_table
+                .get(&symbol_hash)
+                .cloned()
+                .unwrap_or_else(|| label.to_string());
             let mut left_stripped = stripped.clone();
             left_stripped.append(&mut b"_left_env".to_vec());
             let left_env = if let Some(res) = self


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep symbol-table argument metadata even when a preferred/renamed function name is used during DWARF decoration
- make function-signature lookup work for both hashed labels (e.g. `_hash_0`) and direct remapped labels (e.g. `scan`, `escape-steps`)
- ensure `decorate_function` continues to emit friendly names while sourcing argument structure from `match_function`
- avoid falling back to `ENV` for renamed functions that have explicit argument lists in `.sym`

## Testing
- `cargo build --bin armtx`
- `./resources/tests/test_mandelbrot.sh`
- `./resources/tests/test_mandelbrot_gdb.sh` with scripted breakpoints/`info args` verification on:
  - `escape-steps`
  - `basic-scanline`
  - `scan`
  - `stringify-row`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0de7ad8-40da-4f7c-ac48-47a61467c424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0de7ad8-40da-4f7c-ac48-47a61467c424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

