### PR TITLE
Improve DWARF statement boundaries for better gdb step behavior

### DIFF
--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -618,6 +618,7 @@ struct DwarfBuilder {
     dwarf: Dwarf,
     frame_table: FrameTable,
     cfi_cie_id: Option<CieId>,
+    last_row_source: Option<(String, u64, u64)>,
 }
 
 struct VariableLocationInfo<'a> {
@@ -769,6 +770,7 @@ impl DwarfBuilder {
             dwarf,
             frame_table: FrameTable::default(),
             cfi_cie_id: None,
+            last_row_source: None,
         };
         let cfi_encoding = Encoding {
             address_size: 4,
@@ -855,7 +857,7 @@ impl DwarfBuilder {
         addr: usize,
         loc: &Srcloc,
         source_sexp: &SExp,
-        _instr: Instr,
+        instr: Instr,
         begin_end_block: Option<BeginEndBlock>,
     ) {
         let (file_id, line, col) = if loc.file.starts_with('*') {
@@ -875,20 +877,40 @@ impl DwarfBuilder {
         if !unit.line_program.in_sequence() {
             return;
         }
+        let source_key = (loc.file.to_string(), loc.line as u64, loc.col as u64);
+        let source_changed = self
+            .last_row_source
+            .as_ref()
+            .map(|prev| prev != &source_key)
+            .unwrap_or(true);
+        let control_flow_or_dispatch = matches!(
+            instr,
+            Instr::B(_)
+                | Instr::Bl(_)
+                | Instr::Bx(_)
+                | Instr::Blx(_)
+                | Instr::Swi(_)
+                | Instr::SwiEq(_)
+        );
         let row = unit.line_program.row();
         row.address_offset = (addr - self.seq_addr_start) as u64;
         row.file = file_id;
         row.line = line;
         row.column = col;
-        row.is_statement = addr == self.seq_addr_start;
+        row.is_statement = addr == self.seq_addr_start
+            || begin_end_block == Some(BeginEndBlock::BeginBlock)
+            || source_changed
+            || control_flow_or_dispatch;
         eprintln!("line row {} at {:?}", row.address_offset, loc);
         row.basic_block = begin_end_block == Some(BeginEndBlock::BeginBlock);
         unit.line_program.generate_row();
+        self.last_row_source = Some(source_key);
     }
 
     fn start(&mut self, addr: usize) {
         let unit = self.dwarf.units.get_mut(self.unit_id);
         self.seq_addr_start = addr;
+        self.last_row_source = None;
         unit.line_program.begin_sequence(Some(Address::Constant(
             (addr + self.target_addr as usize) as u64,
         )));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- improve DWARF line-row `is_stmt` marking so stepping lands on more meaningful locations
- mark rows as statements at function/sequence starts, source-location changes, and control-flow/dispatch instructions (`B/BL/BX/BLX/SWI/SWIEQ`)
- track prior source location per sequence to avoid marking every row while still flagging source transitions

## Details
The change updates `DwarfBuilder::add_instr` in `src/compiler/debug/armjit/code.rs`:
- adds lightweight state (`last_row_source`) reset at each line-program sequence start
- computes `source_changed` from `(file, line, column)` compared to previous emitted row
- derives `control_flow_or_dispatch` from instruction kind
- sets `row.is_statement` when any of these are true:
  - first row in sequence
  - begin basic block marker
  - source location changed
  - control flow / dispatch instruction boundary

This is step 1 of the broader DWARF stepping improvements: better statement boundaries without changing function mapping or synthetic-source policy yet.

## Validation
- `cargo build -q`
- regenerated mandelbrot ELF and inspected DWARF line program with:
  - `readelf --debug-dump=rawline program.elf`
  - `readelf --debug-dump=decodedline program.elf`
- confirmed additional `Set is_stmt to 1` events at semantic boundaries and non-trivial statement-row coverage in decoded table.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b94b2b4-efbb-4b7b-9363-4265a2213683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b94b2b4-efbb-4b7b-9363-4265a2213683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

