### PR TITLE
Phase 2-4 DWARF stepping improvements for gdb

### DIFF
--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -15,8 +15,9 @@ use sha2::Sha256;
 use faerie::{ArtifactBuilder, Decl, Link, SectionKind};
 use gimli;
 use gimli::constants::{
-    DW_AT_byte_size, DW_AT_encoding, DW_AT_frame_base, DW_AT_high_pc, DW_AT_language,
-    DW_AT_location, DW_AT_low_pc, DW_AT_name, DW_AT_type, DW_TAG_base_type,
+    DW_AT_byte_size, DW_AT_decl_column, DW_AT_decl_file, DW_AT_decl_line, DW_AT_encoding,
+    DW_AT_frame_base, DW_AT_high_pc, DW_AT_language, DW_AT_location, DW_AT_low_pc, DW_AT_name,
+    DW_AT_type, DW_TAG_base_type,
     DW_TAG_formal_parameter, DW_TAG_pointer_type, DW_TAG_subprogram, DW_TAG_variable, DW_LANG_C99,
 };
 use gimli::write::{
@@ -1132,6 +1133,7 @@ impl DwarfBuilder {
         addr: usize,
         size: usize,
         preferred_name: Option<&str>,
+        decl_loc: &Srcloc,
     ) -> Option<String> {
         let mut fde = FrameDescriptionEntry::new(
             Address::Constant((self.target_addr as usize + addr) as u64),
@@ -1185,6 +1187,9 @@ impl DwarfBuilder {
             subprogram_names.push(label.to_string());
         }
         let subprogram_ids = {
+            let (_, decl_file_id) = self.add_file(decl_loc.file.as_str());
+            let decl_line = decl_loc.line as u64;
+            let decl_col = decl_loc.col as u64;
             let unit = self.dwarf.units.get_mut(self.unit_id);
             let mut subprogram_ids = Vec::with_capacity(subprogram_names.len());
             for subprogram_name in subprogram_names.iter() {
@@ -1222,6 +1227,12 @@ impl DwarfBuilder {
                     DW_AT_frame_base,
                     AttributeValue::LocationListRef(loc_list_id),
                 );
+                sub_ent.set(
+                    DW_AT_decl_file,
+                    AttributeValue::FileIndex(Some(decl_file_id)),
+                );
+                sub_ent.set(DW_AT_decl_line, AttributeValue::Udata(decl_line));
+                sub_ent.set(DW_AT_decl_column, AttributeValue::Udata(decl_col));
                 subprogram_ids.push(subprogram_id);
             }
             subprogram_ids
@@ -1856,11 +1867,13 @@ impl Program {
                     self.start_addr, self.current_addr
                 );
                 let preferred_name = self.current_symbol_name.clone();
+                let function_end_addr = self.current_addr + size;
                 if let Some(function_name) = self.dwarf_builder.decorate_function(
                     label,
                     self.start_addr,
-                    self.current_addr - self.start_addr,
+                    function_end_addr.saturating_sub(self.start_addr),
                     preferred_name.as_deref(),
+                    srcloc,
                 ) {
                     eprintln!("end block with function {function_name}");
                     self.function_symbols.insert(label.clone(), function_name);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements phase 2, 3, and 4 of DWARF stepping improvements:
- phase 2: synthetic-source fallback for repeated same-line statement step points
- phase 3: fix subprogram/FDE range coverage to include final function instruction range endpoint
- phase 4: add subprogram declaration source attributes (`decl_file/line/column`)

## Changes
### 1) Synthetic step fallback (phase 2)
- Added stable synthetic expression line cache in `DwarfBuilder`:
  - `synthetic_expr_line_by_key: HashMap<Vec<u8>, u64>`
  - keyed by hash of source range + expression text
- `add_synthetic_line` now reuses synthetic lines instead of creating duplicates.
- In `add_instr`:
  - keep first statement step point on real source line
  - remap repeated statement boundaries on the same real source line to `program.elf.clsp`
  - preserves file/line association while improving forward stepping progression.

### 2) Function range correctness (phase 3)
- In `Program::push_be`, moved end-block function decoration to after instruction size/address advancement.
- This ensures `decorate_function(addr, size)` includes the terminal instruction endpoint.
- Result: `DW_AT_high_pc` and FDE coverage align better with actual generated function extent.

### 3) Subprogram declaration location metadata (phase 4)
- Added `DW_AT_decl_file`, `DW_AT_decl_line`, `DW_AT_decl_column` on each subprogram DIE in `decorate_function`.
- Uses the line-program file index + `Srcloc` coordinates for stronger source anchoring in debugger frame display and stepping context.

## Validation
- `cargo build -q`
- generated `program.elf` from mandelbrot and inspected DWARF:
  - `readelf --debug-dump=decodedline program.elf`
  - `readelf --debug-dump=info program.elf`
- Verified:
  - synthetic statement rows are present for repeated same-line boundaries
  - subprograms now carry `DW_AT_decl_file/line/column`
  - subprogram high_pc endpoint includes final instruction boundary (`...84`, `...e4`, `...54`, etc. where prior output ended 4 bytes earlier).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b94b2b4-efbb-4b7b-9363-4265a2213683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b94b2b4-efbb-4b7b-9363-4265a2213683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

