### PR TITLE
Set default IncludeDesc fingerprint to zeros

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -646,7 +646,9 @@ fn add_main_fingerprint(cf: &mut CompileForm, forms: &[Rc<SExp>]) {
         nl: cf.loc(),
         name: b"main".to_vec(),
         kind: Some(IncludeProcessType::Compiled),
-        fingerprint: sha256tree(form_list),
+        fingerprint: sha256tree(form_list)
+            .try_into()
+            .expect("sha256tree returns 32 bytes"),
     });
 }
 

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -560,7 +560,7 @@ fn compute_export_summary(
             loc.clone(),
             Rc::new(SExp::Cons(
                 loc.clone(),
-                Rc::new(SExp::QuotedString(loc.clone(), b'"', shortname.to_vec())),
+                Rc::new(SExp::Atom(loc.clone(), shortname.to_vec())),
                 Rc::new(SExp::QuotedString(loc, b'x', hash)),
             )),
             list_tail,

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -848,8 +848,8 @@ pub struct IncludeDesc {
     /// Kind of inclusion.  Determines whether dependencies are recursed and
     /// what operation is performed on the retrieved clvm form.
     pub kind: Option<IncludeProcessType>,
-    /// Fingerprint of input
-    pub fingerprint: Vec<u8>,
+    /// Fingerprint of input (SHA-256 tree hash of file bytes when known; otherwise zeros)
+    pub fingerprint: [u8; 32],
 }
 
 impl IncludeDesc {

--- a/src/compiler/diskcache.rs
+++ b/src/compiler/diskcache.rs
@@ -7,7 +7,7 @@ use crate::compiler::sexp::decode_string;
 fn cache_key(cf: &CompileForm) -> String {
     let mut include_fingerprints = Vec::new();
     for include in cf.include_forms.iter() {
-        include_fingerprints.append(&mut include.fingerprint.clone());
+        include_fingerprints.extend_from_slice(&include.fingerprint);
     }
     hex::encode(sha256tree_from_atom(&include_fingerprints))
 }

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -225,7 +225,7 @@ fn sorted_cse_detections_by_applicability(
         .iter()
         .map(|a| (number_of_overlaps(cse_detections, a), a.clone()))
         .collect();
-    detections_with_dependencies.sort_by(|(a, _), (b, _)| a.cmp(b));
+    detections_with_dependencies.sort_by_key(|(a, _)| *a);
     detections_with_dependencies
 }
 

--- a/src/compiler/optimize/depgraph.rs
+++ b/src/compiler/optimize/depgraph.rs
@@ -209,10 +209,8 @@ impl FunctionDependencyGraph {
             HelperForm::Defun(_, defun) => {
                 self.process_expr(&defun.name, defun.body.clone());
             }
-            HelperForm::Defconstant(dc) => {
-                if self.options.with_constants {
-                    self.process_expr(&dc.name, dc.body.clone());
-                }
+            HelperForm::Defconstant(dc) if self.options.with_constants => {
+                self.process_expr(&dc.name, dc.body.clone());
             }
             _ => {}
         }

--- a/src/compiler/preprocessor/macros.rs
+++ b/src/compiler/preprocessor/macros.rs
@@ -45,12 +45,10 @@ fn match_number(body: Rc<SExp>) -> Result<MatchedNumber, CompileErr> {
         SExp::QuotedString(ql, b'x', b) => {
             return Ok(MatchedNumber::MatchedHex(ql.clone(), b.clone()));
         }
-        SExp::Atom(al, b) => {
-            // An atom with unprintable characters is rendered as an integer.
-            if !printable(b, false) {
-                let to_integer = number_from_u8(b);
-                return Ok(MatchedNumber::MatchedInt(al.clone(), to_integer));
-            }
+        // An atom with unprintable characters is rendered as an integer.
+        SExp::Atom(al, b) if !printable(b, false) => {
+            let to_integer = number_from_u8(b);
+            return Ok(MatchedNumber::MatchedInt(al.clone(), to_integer));
         }
         SExp::Nil(il) => {
             return Ok(MatchedNumber::MatchedInt(il.clone(), bi_zero()));

--- a/src/compiler/preprocessor/mod.rs
+++ b/src/compiler/preprocessor/mod.rs
@@ -636,7 +636,9 @@ impl Preprocessor {
             self.opts.read_new_file(self.opts.filename(), filename_clsp)
         {
             // Hash newly read input.
-            let content_hash = sha256tree_from_atom(&content);
+            let content_hash: [u8; 32] = sha256tree_from_atom(&content)
+                .try_into()
+                .expect("sha256tree_from_atom returns 32 bytes");
             includes.push(IncludeDesc {
                 kw: kw.clone(),
                 nl: nl.clone(),
@@ -668,7 +670,9 @@ impl Preprocessor {
             nl: nl.clone(),
             name: full_name.as_bytes().to_vec(),
             kind: Some(IncludeProcessType::Module(Box::new(kind.clone()))),
-            fingerprint: sha256tree_from_atom(&content),
+            fingerprint: sha256tree_from_atom(&content)
+                .try_into()
+                .expect("sha256tree_from_atom returns 32 bytes"),
         });
 
         Ok(res)
@@ -805,7 +809,9 @@ impl Preprocessor {
         let (full_name, content) = self.opts.read_new_file(self.opts.filename(), name_string)?;
 
         // Hash newly read input.
-        let content_hash = sha256tree_from_atom(&content);
+        let content_hash: [u8; 32] = sha256tree_from_atom(&content)
+            .try_into()
+            .expect("sha256tree_from_atom returns 32 bytes");
         includes.push(IncludeDesc {
             name: full_name.as_bytes().to_vec(),
             fingerprint: content_hash,
@@ -1116,7 +1122,7 @@ impl Preprocessor {
                 nl: import.nl.clone(),
                 name: fname.clone(),
                 kind: Some(mod_kind.clone()),
-                fingerprint: Vec::new(),
+                fingerprint: [0u8; 32],
             }),
             mod_kind,
             fname.clone(),
@@ -1180,7 +1186,7 @@ impl Preprocessor {
                 nl: nl.clone(),
                 name: fname.clone(),
                 kind: None,
-                fingerprint: Vec::new(),
+                fingerprint: [0u8; 32],
             })));
         }
 
@@ -1217,7 +1223,7 @@ impl Preprocessor {
                         nl: nl.clone(),
                         kind: Some(IncludeProcessType::Hex),
                         name: fname.clone(),
-                        fingerprint: Vec::new(),
+                        fingerprint: [0u8; 32],
                     }),
                     IncludeProcessType::Hex,
                     name.clone(),
@@ -1229,7 +1235,7 @@ impl Preprocessor {
                         nl: nl.clone(),
                         kind: Some(IncludeProcessType::Bin),
                         name: fname.clone(),
-                        fingerprint: Vec::new(),
+                        fingerprint: [0u8; 32],
                     }),
                     IncludeProcessType::Bin,
                     name.clone(),
@@ -1241,7 +1247,7 @@ impl Preprocessor {
                         nl: nl.clone(),
                         kind: Some(IncludeProcessType::SExpression),
                         name: fname.clone(),
-                        fingerprint: Vec::new(),
+                        fingerprint: [0u8; 32],
                     }),
                     IncludeProcessType::SExpression,
                     name.clone(),
@@ -1274,7 +1280,7 @@ impl Preprocessor {
                     nl: nl.clone(),
                     kind: Some(IncludeProcessType::Compiled),
                     name: fname.clone(),
-                    fingerprint: Vec::new(),
+                    fingerprint: [0u8; 32],
                 }),
                 IncludeProcessType::Compiled,
                 name.clone(),

--- a/src/compiler/rename.rs
+++ b/src/compiler/rename.rs
@@ -94,12 +94,11 @@ pub fn rename_in_cons(
 /* Returns a list of pairs containing the old and new atom names */
 fn invent_new_names_sexp(body: Rc<SExp>) -> Vec<(Vec<u8>, Vec<u8>)> {
     match body.borrow() {
-        SExp::Atom(_, name) => {
-            if name != b"@" {
-                vec![(name.to_vec(), gensym(name.to_vec()))]
-            } else {
-                vec![]
-            }
+        SExp::Atom(_, name) if name != b"@" => {
+            vec![(name.to_vec(), gensym(name.to_vec()))]
+        }
+        SExp::Atom(_, _) => {
+            vec![]
         }
         SExp::Cons(_, head, tail) => {
             let mut head_list = invent_new_names_sexp(head.clone());

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -1220,25 +1220,17 @@ impl<const N: usize> SelectNode<Srcloc, (Srcloc, String)> for AtomValue<&[u8; N]
     fn select_nodes(&self, s: Rc<SExp>) -> Result<Srcloc, (Srcloc, String)> {
         let AtomValue::Here(name) = self;
         match s.borrow() {
-            SExp::Nil(l) => {
-                if name.is_empty() {
-                    return Ok(l.clone());
-                }
+            SExp::Nil(l) if name.is_empty() => {
+                return Ok(l.clone());
             }
-            SExp::Atom(l, n) => {
-                if n == name {
-                    return Ok(l.clone());
-                }
+            SExp::Atom(l, n) if n == name => {
+                return Ok(l.clone());
             }
-            SExp::QuotedString(l, _, n) => {
-                if n == name {
-                    return Ok(l.clone());
-                }
+            SExp::QuotedString(l, _, n) if n == name => {
+                return Ok(l.clone());
             }
-            SExp::Integer(l, i) => {
-                if &u8_from_number(i.clone()) == name {
-                    return Ok(l.clone());
-                }
+            SExp::Integer(l, i) if &u8_from_number(i.clone()) == name => {
+                return Ok(l.clone());
             }
             _ => {}
         }


### PR DESCRIPTION
Use an array of zero bytes instead of nil to represent "no fingerprint".
Doing this allows concatenation of an ordered set of signatures to uniquely represent that set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how include fingerprints are represented and concatenated into the on-disk cache key, which can affect cache hit/miss behavior across builds. Low functional risk beyond caching, but any mismatch in fingerprint population could cause incorrect reuse or unnecessary recompiles.
> 
> **Overview**
> **Normalizes include fingerprinting for caching.** `IncludeDesc.fingerprint` is changed from a variable-length `Vec<u8>` to a fixed `[u8; 32]`, with *unknown fingerprints represented as 32 zero bytes*.
> 
> Fingerprint calculation paths now explicitly `try_into()` the 32-byte tree hash, and the disk cache key builder concatenates fingerprints via `extend_from_slice`, ensuring deterministic key material even when some includes previously had “no fingerprint”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22924f41adad31cd8b5cdcb83f37cdb93f0c11b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->