### PR TITLE
Bump version to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "chialisp"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "binascii",
  "chia-bls 0.42.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chialisp"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 authors = ["Art Yerkes <art.yerkes@gmail.com>"]
 description = "tools for working with chialisp language; compiler, repl, python and wasm bindings"

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "chialisp"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "binascii",
  "chia-bls 0.42.0",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_tools_wasm"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chialisp",
  "clvmr",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_wasm"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2018"
 authors = ["Art Yerkes <art.yerkes@gmail.com>"]
 description = "tools for working with chialisp language; compiler, repl, python and wasm bindings"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release-only change that updates crate versions and lockfiles without altering runtime logic.
> 
> **Overview**
> Updates the published versions to `0.4.4` for both the main `chialisp` crate and the `wasm` package (`clvm_tools_wasm`).
> 
> Regenerates `Cargo.lock` files to reflect the new crate versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9f94eeb5c49de5671678f9994e7744cebee997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->