### PR TITLE
Add wasm ARM ELF compile entrypoint

### DIFF
--- a/src/classic/bins/armtx.rs
+++ b/src/classic/bins/armtx.rs
@@ -6,11 +6,16 @@ use chialisp::compiler::debug::armjit::cmd::{compile_to_arm_elf, spin_up_emulati
 fn run_arm_conversion() -> Result<(), String> {
     let args: Args = argh::from_env();
 
-    let (elf_out, symbol_table) = compile_to_arm_elf(&args)?;
+    let arm_elf = compile_to_arm_elf(&args)?;
 
     // copy all in-memory sections from the ELF file into system RAM
-    fs::write(&args.output, &elf_out).map_err(|e| format!("could not write elf file: {e:?}"))?;
-    spin_up_emulation(&elf_out, Rc::new(symbol_table), Some(9001))?;
+    fs::write(&args.output, &arm_elf.object_file)
+        .map_err(|e| format!("could not write elf file: {e:?}"))?;
+    spin_up_emulation(
+        &arm_elf.object_file,
+        Rc::new(arm_elf.symbol_table),
+        Some(9001),
+    )?;
     Ok(())
 }
 

--- a/src/compiler/debug/armjit/cmd.rs
+++ b/src/compiler/debug/armjit/cmd.rs
@@ -16,7 +16,7 @@ use crate::classic::platform::argparse::ArgumentValue;
 use crate::compiler::clvm::convert_from_clvm_rs;
 use crate::compiler::compiler::{compile_file, DefaultCompilerOpts};
 use crate::compiler::comptypes::CompilerOpts;
-use crate::compiler::debug::armjit::code::{Program, TARGET_ADDR};
+use crate::compiler::debug::armjit::code::{ElfObject, Program, TARGET_ADDR};
 use crate::compiler::debug::armjit::emu::Emu;
 use crate::compiler::debug::armjit::emu_stub::{run_stub, start_stub};
 use crate::compiler::debug::build_symbol_table_mut;
@@ -58,9 +58,13 @@ pub fn spin_up_emulation(
     Ok(addr)
 }
 
-pub fn compile_to_arm_elf(args: &Args) -> Result<(Vec<u8>, HashMap<String, String>), String> {
-    let search_paths = args.include.clone();
+pub struct ArmElfCompileOutput {
+    pub object_file: Vec<u8>,
+    pub synthetic_source: String,
+    pub symbol_table: HashMap<String, String>,
+}
 
+pub fn compile_to_arm_elf(args: &Args) -> Result<ArmElfCompileOutput, String> {
     let argfile = if let Ok(res) = fs::read_to_string(&args.filename) {
         res
     } else {
@@ -68,8 +72,6 @@ pub fn compile_to_arm_elf(args: &Args) -> Result<(Vec<u8>, HashMap<String, Strin
         std::process::exit(1);
     };
 
-    let srcloc = Srcloc::start(&args.filename);
-    let mut allocator = Allocator::new();
     let runner: Rc<dyn TRunProgram> = Rc::new(DefaultProgramRunner::new());
     let mut symbol_table = HashMap::new();
 
@@ -153,9 +155,16 @@ pub fn compile_to_arm_elf(args: &Args) -> Result<(Vec<u8>, HashMap<String, Strin
     )
     .expect("should generate");
 
-    let output = program
+    let ElfObject {
+        object_file,
+        synthetic_source,
+    } = program
         .to_elf(&args.output)
         .map_err(|e| format!("failed to create elf output: {e:?}"))?;
 
-    Ok((output, symbol_table))
+    Ok(ArmElfCompileOutput {
+        object_file,
+        synthetic_source,
+        symbol_table,
+    })
 }

--- a/src/compiler/debug/armjit/cmd.rs
+++ b/src/compiler/debug/armjit/cmd.rs
@@ -65,13 +65,16 @@ pub struct ArmElfCompileOutput {
 }
 
 pub fn compile_to_arm_elf(args: &Args) -> Result<ArmElfCompileOutput, String> {
-    let argfile = if let Ok(res) = fs::read_to_string(&args.filename) {
-        res
-    } else {
-        eprintln!("error reading {}", args.filename);
-        std::process::exit(1);
-    };
+    let argfile = fs::read_to_string(&args.filename)
+        .map_err(|_| format!("error reading {}", args.filename))?;
 
+    compile_to_arm_elf_from_source(args, argfile)
+}
+
+pub fn compile_to_arm_elf_from_source(
+    args: &Args,
+    argfile: String,
+) -> Result<ArmElfCompileOutput, String> {
     let runner: Rc<dyn TRunProgram> = Rc::new(DefaultProgramRunner::new());
     let mut symbol_table = HashMap::new();
 

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -2,8 +2,6 @@ use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fmt::Formatter;
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
 use std::mem::swap;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -28,7 +26,6 @@ use gimli::write::{
 use gimli::Arm;
 use gimli::{DW_ATE_unsigned, DwAte, Encoding, Format, LineEncoding};
 use target_lexicon::triple;
-use tempfile::NamedTempFile;
 
 use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero, Bytes, BytesFromType};
 use crate::classic::clvm::casts::bigint_to_bytes_clvm;
@@ -2218,23 +2215,7 @@ impl Program {
             .map_err(|e| format!("link {e:?}"))?;
         }
 
-        eprintln!("get temp file path");
-        let mut file = NamedTempFile::new().map_err(|e| format!("named temp {e:?}"))?;
-        let name = file.path().to_str().unwrap().to_string();
-        eprintln!("open reread");
-        let mut reread_file = File::open(&name).map_err(|e| format!("reopen {e:?}"))?;
-        eprintln!("writing to tmp file");
-        obj.write(file.into_file())
-            .map_err(|e| format!("obj write {e:?}"))?;
-        eprintln!("seek 0");
-        reread_file
-            .seek(SeekFrom::Start(0))
-            .map_err(|e| format!("seek {e:?}"))?;
-        let mut result_buf = Vec::new();
-        eprintln!("seek 0");
-        reread_file
-            .read_to_end(&mut result_buf)
-            .map_err(|e| format!("capture {e:?}"))?;
+        let mut result_buf = obj.emit().map_err(|e| format!("obj emit {e:?}"))?;
 
         // Patch up
         eprintln!("reload elf");

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fmt::Formatter;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::mem::swap;
 use std::path::PathBuf;
@@ -48,6 +48,11 @@ pub const SWI_DISPATCH_INSTRUCTION: usize = 3;
 pub const SWI_PRINT_EXPR: usize = 4;
 
 pub const TARGET_ADDR: u32 = 0x1000;
+
+pub struct ElfObject {
+    pub object_file: Vec<u8>,
+    pub synthetic_source: String,
+}
 
 //
 // Compile each program to clvm, then decompose into arm assembly.
@@ -872,17 +877,12 @@ impl DwarfBuilder {
         line
     }
 
-    fn write_synthetic_source_file(&self) -> Result<(), String> {
+    fn synthetic_source(&self) -> String {
         let mut synthetic_source = self.synthetic_source_lines.join("\n");
         if !synthetic_source.is_empty() {
             synthetic_source.push('\n');
         }
-        fs::write(&self.synthetic_source_path, synthetic_source).map_err(|e| {
-            format!(
-                "write synthetic source {}: {e:?}",
-                self.synthetic_source_path
-            )
-        })
+        synthetic_source
     }
 
     fn add_instr(
@@ -2071,8 +2071,8 @@ impl Program {
         Ok(())
     }
 
-    pub fn to_elf(&self, output: &str) -> Result<Vec<u8>, String> {
-        self.dwarf_builder.write_synthetic_source_file()?;
+    pub fn to_elf(&self, output: &str) -> Result<ElfObject, String> {
+        let synthetic_source = self.dwarf_builder.synthetic_source();
         let mut sections = Vec::new();
         let mut obj = ArtifactBuilder::new(triple!("arm-unknown-unknown-unknown-elf"))
             .name(output.to_owned())
@@ -2253,7 +2253,10 @@ impl Program {
         }
 
         eprintln!("code succeeded");
-        Ok(result_buf)
+        Ok(ElfObject {
+            object_file: result_buf,
+            synthetic_source,
+        })
     }
 
     pub fn new(

--- a/src/compiler/debug/armjit/emu.rs
+++ b/src/compiler/debug/armjit/emu.rs
@@ -937,7 +937,7 @@ impl Emu {
         )
         .expect("should be generatable");
         let elf_data = generator.to_elf(&tmpname).expect("should generate");
-        Emu::run_to_exit(&elf_data, TARGET_ADDR, symbols)
+        Emu::run_to_exit(&elf_data.object_file, TARGET_ADDR, symbols)
     }
 }
 

--- a/src/tests/debug.rs
+++ b/src/tests/debug.rs
@@ -22,12 +22,17 @@ fn run_test_program_with_argument(file: &str, gdb_script: &str, env: &str) -> St
     };
     let (sender, receiver) = channel();
     let t = thread::spawn(move || {
-        let (output, symbols) = compile_to_arm_elf(&args).expect("should compile");
+        let output = compile_to_arm_elf(&args).expect("should compile");
         eprintln!("compile_to_arm_elf succeeded");
-        fs::write(&args.output, &output).expect("should be able to write file");
+        fs::write(&args.output, &output.object_file).expect("should be able to write file");
         eprintln!("elf file written to {}", args.output);
         // Tiny start.
-        let mut emu = Emu::new(&output, TARGET_ADDR, Rc::new(symbols)).unwrap();
+        let mut emu = Emu::new(
+            &output.object_file,
+            TARGET_ADDR,
+            Rc::new(output.symbol_table),
+        )
+        .unwrap();
         let sockaddr = format!("127.0.0.1:0");
         let sock = TcpListener::bind(sockaddr).unwrap();
         let local_addr = sock.local_addr().unwrap();

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -31,6 +31,7 @@ use chialisp::compiler::compiler::{
     extract_program_and_env, path_to_function, rewrite_in_program, DefaultCompilerOpts,
 };
 use chialisp::compiler::comptypes::{CompileErr, CompilerOpts};
+use chialisp::compiler::debug::armjit::cmd::{compile_to_arm_elf, Args as ArmElfArgs};
 use chialisp::compiler::optimize::get_optimizer;
 use chialisp::compiler::prims;
 use chialisp::compiler::repl::Repl;
@@ -321,6 +322,67 @@ pub fn compile(input_js: JsValue, filename_js: JsValue, search_paths_js: Vec<JsV
         false,
     ) {
         Ok(_) => make_compile_output(&result_stream, &symbol_table),
+        Err(e) => create_clvm_runner_err(e),
+    }
+}
+
+// Compile a Chialisp program into an ARM ELF object with DWARF debug info.
+// Returns {"object_file": Uint8Array, "synthetic_source": "...", "symbols": {...}}
+// or {"error": ...}
+#[wasm_bindgen(js_name = compile_to_arm_elf)]
+pub fn compile_to_arm_elf_js(
+    input_js: JsValue,
+    filename_js: JsValue,
+    search_paths_js: Vec<JsValue>,
+    env_js: JsValue,
+) -> JsValue {
+    let input = input_js.as_string().unwrap();
+    let filename = filename_js.as_string().unwrap();
+    let env = env_js.as_string().unwrap();
+    let search_paths: Vec<String> = search_paths_js
+        .iter()
+        .map(|j| j.as_string().unwrap())
+        .collect();
+
+    let args = ArmElfArgs {
+        include: search_paths,
+        output: format!("{filename}.elf"),
+        filename,
+        env,
+        input: Some(input),
+    };
+
+    match compile_to_arm_elf(&args) {
+        Ok(result) => {
+            let array = js_sys::Array::new();
+            array.set(
+                0,
+                js_pair(
+                    JsValue::from_str("object_file"),
+                    js_sys::Uint8Array::from(result.object_file.as_slice()).into(),
+                ),
+            );
+            array.set(
+                1,
+                js_pair(
+                    JsValue::from_str("synthetic_source"),
+                    JsValue::from_str(&result.synthetic_source),
+                ),
+            );
+
+            let symbol_array = js_sys::Array::new();
+            for (idx, (k, v)) in result.symbol_table.iter().enumerate() {
+                symbol_array.set(
+                    idx as u32,
+                    js_pair(JsValue::from_str(k), JsValue::from_str(v)),
+                );
+            }
+            let symbol_object =
+                object_to_value(&js_sys::Object::from_entries(&symbol_array).unwrap());
+            array.set(2, js_pair(JsValue::from_str("symbols"), symbol_object));
+
+            object_to_value(&js_sys::Object::from_entries(&array).unwrap())
+        }
         Err(e) => create_clvm_runner_err(e),
     }
 }

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -31,7 +31,7 @@ use chialisp::compiler::compiler::{
     extract_program_and_env, path_to_function, rewrite_in_program, DefaultCompilerOpts,
 };
 use chialisp::compiler::comptypes::{CompileErr, CompilerOpts};
-use chialisp::compiler::debug::armjit::cmd::{compile_to_arm_elf, Args as ArmElfArgs};
+use chialisp::compiler::debug::armjit::cmd::compile_to_arm_elf_from_source;
 use chialisp::compiler::optimize::get_optimizer;
 use chialisp::compiler::prims;
 use chialisp::compiler::repl::Repl;
@@ -344,15 +344,13 @@ pub fn compile_to_arm_elf_js(
         .map(|j| j.as_string().unwrap())
         .collect();
 
-    let args = ArmElfArgs {
-        include: search_paths,
-        output: format!("{filename}.elf"),
-        filename,
+    match compile_to_arm_elf_from_source(
+        input,
+        filename.clone(),
+        format!("{filename}.elf"),
         env,
-        input: Some(input),
-    };
-
-    match compile_to_arm_elf(&args) {
+        search_paths,
+    ) {
         Ok(result) => {
             let array = js_sys::Array::new();
             array.set(

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -21,7 +21,6 @@ use chialisp::classic::clvm::__type_compatibility__::{Bytes, Stream, Unvalidated
 use chialisp::classic::clvm::serialize::sexp_to_stream;
 use chialisp::classic::clvm_tools::clvmc::compile_clvm_inner;
 use chialisp::classic::clvm_tools::stages::stage_0::{DefaultProgramRunner, TRunProgram};
-use chialisp::compiler::CompileContextWrapper;
 use chialisp::compiler::cldb::{
     hex_to_modern_sexp, CldbOverrideBespokeCode, CldbRun, CldbRunEnv, CldbRunnable,
     CldbSingleBespokeOverride,
@@ -31,13 +30,14 @@ use chialisp::compiler::compiler::{
     extract_program_and_env, path_to_function, rewrite_in_program, DefaultCompilerOpts,
 };
 use chialisp::compiler::comptypes::{CompileErr, CompilerOpts};
-use chialisp::compiler::debug::armjit::cmd::compile_to_arm_elf_from_source;
+use chialisp::compiler::debug::armjit::cmd::{compile_to_arm_elf_from_source, Args as ArmElfArgs};
 use chialisp::compiler::optimize::get_optimizer;
 use chialisp::compiler::prims;
 use chialisp::compiler::repl::Repl;
 use chialisp::compiler::runtypes::RunFailure;
 use chialisp::compiler::sexp::SExp;
 use chialisp::compiler::srcloc::Srcloc;
+use chialisp::compiler::CompileContextWrapper;
 
 extern crate alloc;
 
@@ -344,13 +344,14 @@ pub fn compile_to_arm_elf_js(
         .map(|j| j.as_string().unwrap())
         .collect();
 
-    match compile_to_arm_elf_from_source(
-        input,
-        filename.clone(),
-        format!("{filename}.elf"),
+    let args = ArmElfArgs {
+        include: search_paths,
+        output: format!("{filename}.elf"),
+        filename,
         env,
-        search_paths,
-    ) {
+    };
+
+    match compile_to_arm_elf_from_source(&args, input) {
         Ok(result) => {
             let array = js_sys::Array::new();
             array.set(
@@ -528,14 +529,11 @@ pub fn repl_run_string(repl_id: i32, input: String) -> JsValue {
                     a,
                     repl_container.runner.clone(),
                     &mut symbols,
-                    get_optimizer(&loc, repl_container.opts.clone())?
+                    get_optimizer(&loc, repl_container.opts.clone())?,
                 );
                 r.process_line(&mut wrapper.context, input)
             } else {
-                Err(CompileErr(
-                    loc,
-                    "no such repl".to_string(),
-                ))
+                Err(CompileErr(loc, "no such repl".to_string()))
             }
         })
         .map(|v| v.map(|v| js_object_from_sexp(v.to_sexp()).unwrap_or_else(|e| e)))

--- a/wasm/tests/clvm-tools-interface/src/lib/tests/index.test.ts
+++ b/wasm/tests/clvm-tools-interface/src/lib/tests/index.test.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import { resolve } from 'path';
 import * as assert from 'assert';
 import * as bls_loader from 'bls-signatures';
-const {h, t, Program} = require('../../../../../pkg/clvm_tools_wasm.js');
+const {compile_to_arm_elf, h, t, Program} = require('../../../../../pkg/clvm_tools_wasm.js');
 
 it('Has BLS signatures support', async () => {
     const bls = await bls_loader.default();
@@ -17,6 +17,23 @@ it('Has BLS signatures support', async () => {
 it('Has the "h" function', async () => {
     const unhexed = h('21203031');
     assert.equal([0x21, 0x20, 0x30, 0x31].toString(), unhexed.toString());
+});
+
+it('Can compile chialisp to an ARM ELF object with DWARF symbols', async () => {
+    const program = '(mod (X) (+ X 7))';
+    const result = compile_to_arm_elf(program, 'wasm_arm_elf_test.clsp', [], '(5)');
+    const objectFile: Uint8Array = result.object_file;
+    const syntheticSource: string = result.synthetic_source;
+
+    assert.ok(objectFile instanceof Uint8Array);
+    assert.equal(Buffer.from(objectFile.subarray(0, 4)).toString('hex'), '7f454c46');
+
+    const objectText = Buffer.from(objectFile).toString('latin1');
+    assert.ok(objectText.includes('.debug_info'));
+    assert.ok(objectText.includes('.debug_line'));
+    assert.ok(objectText.includes('.debug_str'));
+    assert.ok(objectText.includes('wasm_arm_elf_test.clsp'));
+    assert.ok(syntheticSource.includes('=>'));
 });
 
 it('Converts uint8arrays', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Return ARM ELF object bytes and synthetic source content from the ARM debug compiler instead of writing synthetic source to disk.
- Add an in-memory ARM ELF compile helper used by wasm while keeping CLI callers reading source files normally.
- Add a wasm-bindgen `compile_to_arm_elf` entrypoint that returns object bytes, synthetic source, and symbols.
- Add a clvm-tools-interface test that compiles a Chialisp program to ELF bytes with DWARF sections.

## Testing
- `cargo check`
- `cargo check --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown`
- `wasm-pack build --release --target=nodejs`
- `npm test -- --runInBand` (in `wasm/tests/clvm-tools-interface`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6bfb58f-03a9-42d5-b907-7f7defbae021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6bfb58f-03a9-42d5-b907-7f7defbae021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

