### PR TITLE
Fix: Last step of convergence loop can report false failure

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -35,7 +35,7 @@ use crate::util::{toposort, u8_from_number, Number, TopoSortItem};
 
 const MACRO_TIME_LIMIT: usize = 1000000;
 pub const CONST_EVAL_LIMIT: usize = 1000000;
-const CONSTANT_GENERATIONS_ALLOWED: usize = 50;
+pub const CONSTANT_GENERATIONS_ALLOWED: usize = 50;
 
 // Tell what kind of lookup is being asked for.
 // ReferenceAsVariable means that references to defuns should appear wrapped so they can be
@@ -2793,8 +2793,9 @@ pub fn codegen(
         let mut prev_repr = Rc::new(SExp::Nil(code_generator.final_env.loc()));
         let mut this_repr = code_generator.final_env.clone();
         let mut steps = 0;
+        let generation_limit = opts.constant_generation_limit();
 
-        while prev_repr != this_repr && steps < CONSTANT_GENERATIONS_ALLOWED {
+        while prev_repr != this_repr && steps < generation_limit {
             // Regenerate constants.
             for h in to_process.iter() {
                 if matches!(h, HelperForm::Defconstant(_)) {
@@ -2826,7 +2827,7 @@ pub fn codegen(
             steps += 1;
         }
 
-        if steps == CONSTANT_GENERATIONS_ALLOWED {
+        if prev_repr != this_repr {
             return Err(CompileErr(
                 Srcloc::start(&opts.filename()),
                 "Constant generation didn't converge in allowed iteration limit".to_string(),

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -19,7 +19,9 @@ use crate::classic::clvm::__type_compatibility__::Stream;
 use crate::classic::clvm::sexp::sexp_as_bin;
 use crate::compiler::cldb::hex_to_modern_sexp;
 use crate::compiler::clvm::{convert_to_clvm_rs, run, sha256tree, NewStyleIntConversion};
-use crate::compiler::codegen::{codegen, hoist_body_let_binding, process_helper_let_bindings};
+use crate::compiler::codegen::{
+    codegen, hoist_body_let_binding, process_helper_let_bindings, CONSTANT_GENERATIONS_ALLOWED,
+};
 use crate::compiler::comptypes::{
     BodyForm, CompileErr, CompileForm, CompileModuleComponent, CompileModuleOutput, CompilerOpts,
     CompilerOutput, ConstantKind, DefunData, Export, FrontendOutput, HelperForm, ImportLongName,
@@ -111,6 +113,7 @@ pub struct DefaultCompilerOpts {
     pub diag_flags: Rc<HashSet<usize>>,
     pub dialect: AcceptedDialect,
     pub module_phase: Option<ModulePhase>,
+    pub constant_generation_limit: usize,
 }
 
 pub fn create_prim_map() -> Rc<HashMap<Vec<u8>, Rc<SExp>>> {
@@ -957,6 +960,9 @@ impl CompilerOpts for DefaultCompilerOpts {
     fn diag_flags(&self) -> Rc<HashSet<usize>> {
         self.diag_flags.clone()
     }
+    fn constant_generation_limit(&self) -> usize {
+        self.constant_generation_limit
+    }
 
     fn set_filename(&self, filename: &str) -> Rc<dyn CompilerOpts> {
         let mut copy = self.clone();
@@ -1026,6 +1032,11 @@ impl CompilerOpts for DefaultCompilerOpts {
     fn set_diag_flags(&self, flags: Rc<HashSet<usize>>) -> Rc<dyn CompilerOpts> {
         let mut copy = self.clone();
         copy.diag_flags = flags;
+        Rc::new(copy)
+    }
+    fn set_constant_generation_limit(&self, limit: usize) -> Rc<dyn CompilerOpts> {
+        let mut copy = self.clone();
+        copy.constant_generation_limit = limit;
         Rc::new(copy)
     }
 
@@ -1137,6 +1148,7 @@ impl DefaultCompilerOpts {
             disassembly_ver: None,
             module_phase: None,
             diag_flags: Rc::new(HashSet::default()),
+            constant_generation_limit: CONSTANT_GENERATIONS_ALLOWED,
         }
     }
 }

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -1005,6 +1005,8 @@ pub trait CompilerOpts {
     /// Specifies flags that were passed down to various consumers.  This is
     /// open ended for various purposes, such as diagnostics.
     fn diag_flags(&self) -> Rc<HashSet<usize>>;
+    /// Maximum iterations for the constant generation convergence loop.
+    fn constant_generation_limit(&self) -> usize;
 
     /// Set main file, creating an opts that treats this file as its main file.
     fn set_filename(&self, new_file: &str) -> Rc<dyn CompilerOpts>;
@@ -1035,6 +1037,8 @@ pub trait CompilerOpts {
     fn set_prim_map(&self, new_map: Rc<HashMap<Vec<u8>, Rc<SExp>>>) -> Rc<dyn CompilerOpts>;
     /// Set the flags this CompilerOpts holds.  Consumers can examine these.
     fn set_diag_flags(&self, new_flags: Rc<HashSet<usize>>) -> Rc<dyn CompilerOpts>;
+    /// Set the maximum iterations for the constant generation convergence loop.
+    fn set_constant_generation_limit(&self, limit: usize) -> Rc<dyn CompilerOpts>;
 
     /// Using the search paths list we have, try to read a file by name,
     /// Returning the expanded path to the file and its content.
@@ -1117,6 +1121,9 @@ pub trait HasCompilerOptsDelegation {
     fn override_diag_flags(&self) -> Rc<HashSet<usize>> {
         self.compiler_opts().diag_flags()
     }
+    fn override_constant_generation_limit(&self) -> usize {
+        self.compiler_opts().constant_generation_limit()
+    }
 
     fn override_set_filename(&self, new_filename: &str) -> Rc<dyn CompilerOpts> {
         self.update_compiler_opts(|o| o.set_filename(new_filename))
@@ -1156,6 +1163,9 @@ pub trait HasCompilerOptsDelegation {
     }
     fn override_set_diag_flags(&self, flags: Rc<HashSet<usize>>) -> Rc<dyn CompilerOpts> {
         self.update_compiler_opts(|o| o.set_diag_flags(flags))
+    }
+    fn override_set_constant_generation_limit(&self, limit: usize) -> Rc<dyn CompilerOpts> {
+        self.update_compiler_opts(|o| o.set_constant_generation_limit(limit))
     }
     fn override_set_prim_map(
         &self,
@@ -1227,6 +1237,9 @@ impl<T: HasCompilerOptsDelegation> CompilerOpts for T {
     fn diag_flags(&self) -> Rc<HashSet<usize>> {
         self.override_diag_flags()
     }
+    fn constant_generation_limit(&self) -> usize {
+        self.override_constant_generation_limit()
+    }
 
     fn module_phase(&self) -> Option<ModulePhase> {
         self.override_module_phase()
@@ -1273,6 +1286,9 @@ impl<T: HasCompilerOptsDelegation> CompilerOpts for T {
     }
     fn set_diag_flags(&self, new_flags: Rc<HashSet<usize>>) -> Rc<dyn CompilerOpts> {
         self.override_set_diag_flags(new_flags)
+    }
+    fn set_constant_generation_limit(&self, limit: usize) -> Rc<dyn CompilerOpts> {
+        self.override_set_constant_generation_limit(limit)
     }
     fn write_new_file(&self, target: &str, content: &[u8]) -> Result<(), CompileErr> {
         self.override_write_new_file(target, content)

--- a/src/tests/compiler/modules.rs
+++ b/src/tests/compiler/modules.rs
@@ -718,3 +718,22 @@ fn test_cl24_fix_always_present() {
         }],
     );
 }
+
+/// Regression: the convergence loop post-check `if steps == limit` cannot
+/// distinguish "converged on the last allowed iteration" from "did not converge".
+/// When convergence happens on exactly the last step, the check incorrectly
+/// returns an error. This test sets the limit to 1 so that any program
+/// converging in one iteration triggers the false positive.
+#[test]
+fn test_convergence_loop_boundary_does_not_false_positive() {
+    let filename = "resources/tests/module/test_staged_constants_multiple_iters.clsp";
+    let content = fs::read_to_string(filename).expect("file should exist");
+    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(filename))
+        .set_search_paths(&["resources/tests/module".to_string()])
+        .set_constant_generation_limit(1);
+    let source_opts = TestModuleCompilerOpts::new(orig_opts);
+    let mut allocator = Allocator::new();
+    let runner = Rc::new(DefaultProgramRunner::new());
+    perform_compile_of_file(&mut allocator, runner, source_opts, filename, &content)
+        .expect("should compile when convergence happens on the last allowed iteration");
+}


### PR DESCRIPTION
The convergence loop exits when either prev_repr == this_repr (success) or steps >= CONSTANT_GENERATIONS_ALLOWED (failure). The post-loop check if steps == CONSTANT_GENERATIONS_ALLOWED cannot distinguish those two cases when convergence actually happens on the very last allowed iteration, and will incorrectly raise "Constant generation didn't converge in allowed iteration limit" for a program that did in fact converge.

Changes Made
Made the limit configurable (src/compiler/comptypes.rs, src/compiler/compiler.rs): Added constant_generation_limit() / set_constant_generation_limit() to CompilerOpts, DefaultCompilerOpts, and the delegation trait. This allows tests to exercise the boundary condition with small limits.

Wrote a regression test (src/tests/compiler/modules.rs): test_convergence_loop_boundary_does_not_false_positive sets the limit to 1 and compiles a module that converges in one iteration, directly triggering the false-positive error.

Fixed the check (src/compiler/codegen.rs): Changed from if steps == generation_limit to if prev_repr != this_repr, which directly tests whether convergence actually happened regardless of step count.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the module constant-generation convergence loop and compiler option plumbing; while the behavioral change is small, it affects core codegen termination/error conditions for module compilation.
> 
> **Overview**
> Fixes a boundary-condition in the module constant-generation convergence loop so compilation no longer errors when convergence happens on the *last* allowed iteration (post-loop check now verifies `prev_repr != this_repr` rather than relying on the step counter).
> 
> Makes the convergence iteration limit configurable via `CompilerOpts` (`constant_generation_limit` + setter), wires it through `DefaultCompilerOpts`, and adds a regression test that sets the limit to `1` to exercise the failing edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e62882049794730a9a842a1671b3b15d2758bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->