### PR TITLE
Decouple armjit debug code from compiler sexp

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,6 +44,11 @@ jobs:
       - name: install wasm-pack
         run: cargo install --version 0.13.1 wasm-pack
 
+      - name: Install gdb multiarch for debug tools test
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdb-multiarch
+
       - name: wasm-pack build and pack
         run: wasm-pack build --release --target=nodejs wasm && wasm-pack pack wasm
 

--- a/src/classic/bins/armtx.rs
+++ b/src/classic/bins/armtx.rs
@@ -11,7 +11,7 @@ fn run_arm_conversion() -> Result<(), String> {
     // copy all in-memory sections from the ELF file into system RAM
     (|| {
         fs::write(&args.output, &arm_elf.object_file)?;
-        fs::write(&format!("{}.clsp", args.output), &arm_elf.synthetic_source)
+        fs::write(format!("{}.clsp", args.output), &arm_elf.synthetic_source)
     })()
     .map_err(|e| format!("could not write elf file: {e:?}"))?;
 

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fmt::Formatter;
@@ -28,12 +27,14 @@ use gimli::{DW_ATE_unsigned, DwAte, Encoding, Format, LineEncoding};
 use target_lexicon::triple;
 
 use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero, Bytes, BytesFromType};
-use crate::classic::clvm::casts::bigint_to_bytes_clvm;
-use crate::compiler::clvm::{sha256tree, truthy};
-use crate::compiler::comptypes::CompileForm;
 use crate::compiler::debug::armjit::load::{write_u32, ElfLoader};
-use crate::compiler::sexp::{decode_string, parse_sexp, Atom, NodeSel, SExp, SelectNode, ThisNode};
-use crate::compiler::srcloc::Srcloc;
+use crate::compiler::debug::{
+    debug_decode_string as decode_string, debug_dequote as dequote,
+    debug_find_all_by_hash as find_all_by_hash, debug_is_atom as is_atom,
+    debug_is_wrapped_atom as is_wrapped_atom, debug_parse_sexp as parse_sexp,
+    debug_sha256tree as sha256tree, debug_start_loc, ConcreteSExp, DebugSExp, DebugSExpValue,
+    Srcloc,
+};
 use crate::util::Number;
 
 pub const NEXT_ALLOC_OFFSET: i32 = 0;
@@ -840,7 +841,7 @@ impl DwarfBuilder {
         self.add_file_having_dirid(dirid, &filename)
     }
 
-    fn synthetic_expr_key(loc: &Srcloc, source_sexp: &SExp) -> Vec<u8> {
+    fn synthetic_expr_key(loc: &Srcloc, source_sexp: &impl fmt::Display) -> Vec<u8> {
         let mut hasher = Sha256::new();
         hasher.update(loc.file.as_bytes());
         hasher.update((loc.line as u64).to_le_bytes());
@@ -853,7 +854,7 @@ impl DwarfBuilder {
         hasher.finalize().to_vec()
     }
 
-    fn add_synthetic_line(&mut self, loc: &Srcloc, source_sexp: &SExp) -> u64 {
+    fn add_synthetic_line(&mut self, loc: &Srcloc, source_sexp: &impl fmt::Display) -> u64 {
         let synthetic_key = Self::synthetic_expr_key(loc, source_sexp);
         if let Some(line) = self.synthetic_expr_line_by_key.get(&synthetic_key) {
             return *line;
@@ -886,7 +887,7 @@ impl DwarfBuilder {
         &mut self,
         addr: usize,
         loc: &Srcloc,
-        source_sexp: &SExp,
+        source_sexp: &impl fmt::Display,
         instr: Instr,
         begin_end_block: Option<BeginEndBlock>,
     ) {
@@ -1056,69 +1057,61 @@ impl DwarfBuilder {
         locations: &[VariableLocationInfo],
         here: Number,
         path: Number,
-        args: Rc<SExp>,
+        args: impl DebugSExp,
     ) {
         eprintln!("add_arguments {here} {path} {args}");
-        if let SExp::Cons(_, a, b) = args.borrow() {
-            self.add_arguments(
-                subprogram_id,
-                locations,
-                here.clone() << 1,
-                path.clone(),
-                a.clone(),
-            );
-            self.add_arguments(
-                subprogram_id,
-                locations,
-                here.clone() << 1,
-                path | here,
-                b.clone(),
-            );
-        } else if let SExp::Atom(_, a) = args.borrow() {
-            let argname = decode_string(a);
-            let unit = self.dwarf.units.get_mut(self.unit_id);
+        match args.explode() {
+            DebugSExpValue::Cons(_, a, b) => {
+                self.add_arguments(subprogram_id, locations, here.clone() << 1, path.clone(), a);
+                self.add_arguments(subprogram_id, locations, here.clone() << 1, path | here, b);
+            }
+            DebugSExpValue::Atom(_, a) => {
+                let argname = decode_string(&a);
+                let unit = self.dwarf.units.get_mut(self.unit_id);
 
-            let mut loclist = Vec::new();
+                let mut loclist = Vec::new();
 
-            for l in locations.iter() {
-                let mut expr = (l.start_expr)();
+                for l in locations.iter() {
+                    let mut expr = (l.start_expr)();
 
-                let mut i = bi_one();
-                while i < here {
-                    if (path.clone() & i.clone()) != bi_zero() {
-                        expr.op_plus_uconst(4);
+                    let mut i = bi_one();
+                    while i < here {
+                        if (path.clone() & i.clone()) != bi_zero() {
+                            expr.op_plus_uconst(4);
+                        }
+                        expr.op_deref();
+                        i <<= 1;
                     }
-                    expr.op_deref();
-                    i <<= 1;
+
+                    loclist.push(Location::StartEnd {
+                        begin: Address::Constant(l.beginning),
+                        end: Address::Constant(l.end),
+                        data: expr,
+                    });
                 }
 
-                loclist.push(Location::StartEnd {
-                    begin: Address::Constant(l.beginning),
-                    end: Address::Constant(l.end),
-                    data: expr,
-                });
+                let loc_list_id = unit.locations.add(LocationList(loclist));
+
+                let at_id = unit.add(subprogram_id, DW_TAG_formal_parameter);
+                let at_ent = unit.get_mut(at_id);
+                at_ent.set(
+                    DW_AT_name,
+                    AttributeValue::String(argname.as_bytes().to_vec()),
+                );
+                at_ent.set(DW_AT_type, AttributeValue::UnitRef(self.pointer_type));
+                at_ent.set(DW_AT_location, AttributeValue::LocationListRef(loc_list_id));
+
+                /*
+                let at_id2 = unit.add(subprogram_id, DW_TAG_variable);
+                let at_ent = unit.get_mut(at_id2);
+                at_ent.set(
+                    DW_AT_name,
+                    AttributeValue::String(argname.as_bytes().to_vec()),
+                );
+                at_ent.set(DW_AT_type, AttributeValue::UnitRef(self.pointer_type));
+                */
             }
-
-            let loc_list_id = unit.locations.add(LocationList(loclist));
-
-            let at_id = unit.add(subprogram_id, DW_TAG_formal_parameter);
-            let at_ent = unit.get_mut(at_id);
-            at_ent.set(
-                DW_AT_name,
-                AttributeValue::String(argname.as_bytes().to_vec()),
-            );
-            at_ent.set(DW_AT_type, AttributeValue::UnitRef(self.pointer_type));
-            at_ent.set(DW_AT_location, AttributeValue::LocationListRef(loc_list_id));
-
-            /*
-            let at_id2 = unit.add(subprogram_id, DW_TAG_variable);
-            let at_ent = unit.get_mut(at_id2);
-            at_ent.set(
-                DW_AT_name,
-                AttributeValue::String(argname.as_bytes().to_vec()),
-            );
-            at_ent.set(DW_AT_type, AttributeValue::UnitRef(self.pointer_type));
-            */
+            _ => {}
         }
     }
 
@@ -1224,7 +1217,7 @@ impl DwarfBuilder {
             subprogram_ids
         };
         eprintln!("about to parse args");
-        let srcloc = Srcloc::start("*args*");
+        let srcloc = debug_start_loc("*args*");
         if let Ok(parsed) = parse_sexp(srcloc.clone(), args.bytes()) {
             let self_u32_type = self.u32_type;
             let early_reg_closure = move || {
@@ -1330,7 +1323,7 @@ impl Constant {
     }
 }
 
-pub struct Program {
+pub struct Program<T: DebugSExp = ConcreteSExp> {
     program: HashMap<String, Srcloc>,
     target_addr: u32,
     finished_insns: Vec<Instr>,
@@ -1339,7 +1332,7 @@ pub struct Program {
     encounters_of_code: HashMap<Vec<u8>, usize>,
     labels_by_hash: HashMap<Vec<u8>, String>,
     done_programs: HashSet<String>,
-    waiting_programs: Vec<(String, Rc<SExp>)>,
+    waiting_programs: Vec<(String, T)>,
     constants: HashMap<Vec<u8>, Constant>,
     symbol_table: Rc<HashMap<String, String>>,
     current_symbol: Option<String>,
@@ -1351,7 +1344,7 @@ pub struct Program {
     dwarf_builder: DwarfBuilder,
 }
 
-impl fmt::Display for Program {
+impl<T: DebugSExp> fmt::Display for Program<T> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let write_vec = |f: &mut Formatter, v: &[Instr]| -> fmt::Result {
             for i in v.iter() {
@@ -1368,78 +1361,11 @@ fn hexify(v: &[u8]) -> String {
     Bytes::new(Some(BytesFromType::Raw(v.to_vec()))).hex()
 }
 
-fn is_atom(a: Rc<SExp>) -> Option<(Srcloc, Vec<u8>)> {
-    match a.borrow() {
-        SExp::Cons(_, _, _) => None,
-        SExp::Nil(l) => Some((l.clone(), Vec::new())),
-        SExp::Atom(l, a) => Some((l.clone(), a.clone())),
-        SExp::QuotedString(l, _, a) => Some((l.clone(), a.clone())),
-        SExp::Integer(l, i) => {
-            let bytes = bigint_to_bytes_clvm(&i);
-            Some((l.clone(), bytes.data().clone()))
-        }
-    }
-}
-
-fn is_wrapped_atom(a: Rc<SExp>) -> Option<(Srcloc, Vec<u8>)> {
-    if let Ok(NodeSel::Cons((l, a), n)) = NodeSel::Cons(Atom::Here(()), ThisNode).select_nodes(a) {
-        if truthy(n) {
-            return None;
-        }
-
-        return Some((l.clone(), a));
-    }
-
-    None
-}
-
-fn dequote(a: Rc<SExp>) -> Option<Rc<SExp>> {
-    if let Ok(NodeSel::Cons(_q, v)) = NodeSel::Cons(Atom::Here("\x01"), ThisNode).select_nodes(a) {
-        return Some(v.clone());
-    }
-
-    None
-}
-
 pub fn swi_print(register: usize, label: usize) -> usize {
     SWI_PRINT_EXPR | register << 4 | label << 8
 }
 
-fn collect_by_hash(hash: &[u8], sexp: Rc<SExp>, matches: &mut Vec<Rc<SExp>>) -> Vec<u8> {
-    if let SExp::Cons(_, a, b) = &*sexp {
-        let hash_a = collect_by_hash(hash, a.clone(), matches);
-        let hash_b = collect_by_hash(hash, b.clone(), matches);
-        let mut hasher = Sha256::new();
-        hasher.update([2]);
-        hasher.update(&hash_a);
-        hasher.update(&hash_b);
-        let my_hash = hasher.finalize().to_vec();
-        if my_hash == hash {
-            matches.push(sexp);
-        }
-        my_hash
-    } else {
-        let the_hash = sha256tree(sexp.clone());
-        if the_hash == hash {
-            matches.push(sexp);
-        }
-        the_hash
-    }
-}
-
-fn find_all_by_hash(hash: &[u8], sexp: Rc<SExp>) -> Vec<Rc<SExp>> {
-    let mut matches = Vec::new();
-    collect_by_hash(hash, sexp, &mut matches);
-    matches
-}
-
-struct Function {
-    left_env: bool,
-    args: Rc<SExp>,
-    name: String,
-}
-
-impl Program {
+impl<T: DebugSExp> Program<T> {
     fn get_renamed_function_label(&self, hash: &[u8]) -> Option<String> {
         let hash_string = hex::encode(hash);
         self.renamed_symbols.get(&hash_string).cloned()
@@ -1467,23 +1393,23 @@ impl Program {
         return format!("_{}_{n}", hexify(hash));
     }
 
-    fn do_throw(&mut self, source_sexp: Rc<SExp>, loc: &Srcloc, hash: &[u8]) {
+    fn do_throw(&mut self, source_sexp: T, loc: &Srcloc, hash: &[u8]) {
         self.load_atom(source_sexp.clone(), loc, hash, hash);
         self.push(source_sexp.clone(), loc, Instr::Swi(SWI_PRINT_EXPR));
         self.push(source_sexp, loc, Instr::Swi(SWI_THROW));
     }
 
-    fn add_sexp(&mut self, loc: &Srcloc, hash: &[u8], s: Rc<SExp>) -> String {
+    fn add_sexp(&mut self, loc: &Srcloc, hash: &[u8], s: T) -> String {
         if let Some(lbl) = self.constants.get(hash) {
             return lbl.label();
         }
 
-        match s.borrow() {
-            SExp::Cons(_l, a, b) => {
+        match s.explode() {
+            DebugSExpValue::Cons(_l, a, b) => {
                 let a_hash = sha256tree(a.clone());
                 let b_hash = sha256tree(b.clone());
-                let a_label = self.add_sexp(loc, &a_hash, a.clone());
-                let b_label = self.add_sexp(loc, &b_hash, b.clone());
+                let a_label = self.add_sexp(loc, &a_hash, a);
+                let b_label = self.add_sexp(loc, &b_hash, b);
                 let label = format!("_{}", hexify(hash));
                 self.constants.insert(
                     hash.to_vec(),
@@ -1491,34 +1417,26 @@ impl Program {
                 );
                 label
             }
-            SExp::Nil(_) => self.add_atom(hash, &[]),
-            SExp::Atom(_, a) => self.add_atom(hash, &a),
-            SExp::QuotedString(_, _, a) => self.add_atom(hash, &a),
-            SExp::Integer(_, i) => {
-                let v = bigint_to_bytes_clvm(&i).data().clone();
-                self.add_atom(hash, &v)
-            }
+            _ => self.add_atom(
+                hash,
+                &s.atom_bytes()
+                    .expect("non-cons debug sexp should atomize")
+                    .1,
+            ),
         }
     }
 
-    fn load_sexp(&mut self, source_sexp: Rc<SExp>, loc: &Srcloc, hash: &[u8], s: Rc<SExp>) {
+    fn load_sexp(&mut self, source_sexp: T, loc: &Srcloc, hash: &[u8], s: T) {
         let label = self.add_sexp(loc, hash, s);
         self.push(source_sexp, loc, Instr::Lea(Register::R(0), label));
     }
 
-    fn first_rest(
-        &mut self,
-        source_sexp: Rc<SExp>,
-        loc: &Srcloc,
-        hash: &[u8],
-        lst: &[SExp],
-        offset: i32,
-    ) {
+    fn first_rest(&mut self, source_sexp: T, loc: &Srcloc, hash: &[u8], lst: &[T], offset: i32) {
         if lst.len() != 1 {
             return self.do_throw(source_sexp, loc, hash);
         }
 
-        let subexp = self.add(Rc::new(lst[0].clone()));
+        let subexp = self.add(lst[0].clone());
         for i in &[
             Instr::Addi(Register::R(0), Register::R(7), 0),
             // Determine if the result is a cons.
@@ -1540,9 +1458,9 @@ impl Program {
         loc: &Srcloc,
         hash: &[u8],
         a: &[u8],
-        b: Rc<SExp>,
+        b: T,
         treat_as_quoted: bool,
-        source_sexp: Rc<SExp>,
+        source_sexp: T,
     ) {
         if treat_as_quoted {
             todo!();
@@ -1573,7 +1491,7 @@ impl Program {
                 return self.do_throw(source_sexp, loc, hash);
             }
 
-            let env_comp = self.add(Rc::new(lst[1].clone()));
+            let env_comp = self.add(lst[1].clone());
             for i in &[
                 Instr::Addi(Register::R(0), Register::R(7), 0),
                 Instr::Bl(env_comp),
@@ -1582,7 +1500,7 @@ impl Program {
                 self.push(source_sexp.clone(), loc, i.clone());
             }
 
-            if let Some(quoted_code) = dequote(Rc::new(lst[0].clone())) {
+            if let Some(quoted_code) = dequote(lst[0].clone()) {
                 // Short circuit by reading out the quoted code and running it.
                 let code_comp = self.add(quoted_code.clone());
 
@@ -1594,7 +1512,7 @@ impl Program {
                     self.push(source_sexp.clone(), loc, i.clone());
                 }
             } else {
-                let code_comp = self.add(Rc::new(lst[0].clone()));
+                let code_comp = self.add(lst[0].clone());
 
                 for i in &[
                     Instr::Addi(Register::R(0), Register::R(7), 0),
@@ -1620,9 +1538,9 @@ impl Program {
                 return self.do_throw(source_sexp, loc, hash);
             }
 
-            let else_clause = self.add(Rc::new(lst[2].clone()));
-            let then_clause = self.add(Rc::new(lst[1].clone()));
-            let cond_clause = self.add(Rc::new(lst[0].clone()));
+            let else_clause = self.add(lst[2].clone());
+            let then_clause = self.add(lst[1].clone());
+            let cond_clause = self.add(lst[0].clone());
 
             for i in &[
                 Instr::Addi(Register::R(0), Register::R(7), 0),
@@ -1649,8 +1567,8 @@ impl Program {
                 return self.do_throw(source_sexp, loc, hash);
             }
 
-            let rest_label = self.add(Rc::new(lst[1].clone()));
-            let first_label = self.add(Rc::new(lst[0].clone()));
+            let rest_label = self.add(lst[1].clone());
+            let first_label = self.add(lst[0].clone());
 
             for i in &[
                 Instr::Addi(Register::R(0), Register::R(7), 0),
@@ -1678,7 +1596,7 @@ impl Program {
             return self.first_rest(source_sexp, loc, hash, &lst, 4);
         } else {
             // Ensure we have this sexp loadable as data.
-            let operator_sexp = Rc::new(SExp::Atom(loc.clone(), a.to_vec()));
+            let operator_sexp = T::atom(loc.clone(), a);
             let atom_hash = sha256tree(operator_sexp.clone());
             let label = self.add_atom(&atom_hash, a);
             eprintln!("load {label} for general operator {operator_sexp}\n");
@@ -1691,7 +1609,7 @@ impl Program {
             // For each subexpression, call it and replace R4 with (cons R0 R4)
             for item in lst.iter().rev() {
                 eprintln!("load clause {item} for operator {operator_sexp}");
-                let clause_label = self.add(Rc::new(item.clone()));
+                let clause_label = self.add(item.clone());
                 for i in &[
                     // Load the allocator ptr into R0.
                     Instr::Ldr(Register::R(0), Register::R(5), NEXT_ALLOC_OFFSET),
@@ -1730,7 +1648,7 @@ impl Program {
     }
 
     // R0 = the address of the env block.
-    fn env_select(&mut self, source_sexp: Rc<SExp>, loc: &Srcloc, hash: &[u8], v: &[u8]) {
+    fn env_select(&mut self, source_sexp: T, loc: &Srcloc, hash: &[u8], v: &[u8]) {
         if v.is_empty() {
             self.load_atom(source_sexp, loc, hash, v);
             return;
@@ -1787,12 +1705,12 @@ impl Program {
         label
     }
 
-    fn load_atom(&mut self, source_sexp: Rc<SExp>, loc: &Srcloc, hash: &[u8], v: &[u8]) {
+    fn load_atom(&mut self, source_sexp: T, loc: &Srcloc, hash: &[u8], v: &[u8]) {
         let label = self.add_atom(hash, v);
         self.push(source_sexp, loc, Instr::Lea(Register::R(0), label));
     }
 
-    fn add(&mut self, sexp: Rc<SExp>) -> String {
+    fn add(&mut self, sexp: T) -> String {
         let hash = sha256tree(sexp.clone());
         if let Some(existing_label) = self.labels_by_hash.get(&hash) {
             return existing_label.clone();
@@ -1814,7 +1732,7 @@ impl Program {
 
     fn push_be(
         &mut self,
-        source_sexp: Rc<SExp>,
+        source_sexp: T,
         srcloc: &Srcloc,
         instr: Instr,
         begin_end_block: Option<BeginEndBlock>,
@@ -1871,7 +1789,7 @@ impl Program {
             self.dwarf_builder.add_instr(
                 self.current_addr,
                 srcloc,
-                source_sexp.as_ref(),
+                &source_sexp,
                 insert_instr,
                 begin_end_block,
             );
@@ -1879,7 +1797,7 @@ impl Program {
         }
     }
 
-    fn push(&mut self, source_sexp: Rc<SExp>, srcloc: &Srcloc, instr: Instr) {
+    fn push(&mut self, source_sexp: T, srcloc: &Srcloc, instr: Instr) {
         self.push_be(source_sexp, srcloc, instr, None);
     }
 
@@ -1912,8 +1830,8 @@ impl Program {
             }
 
             // Translate body.
-            match sexp.borrow() {
-                SExp::Cons(l, a, b) => {
+            match sexp.explode() {
+                DebugSExpValue::Cons(l, a, b) => {
                     if let Some((loc, a)) = is_atom(a.clone()) {
                         // do quoted operator
                         self.do_operator(&loc, &hash, &a, b.clone(), false, sexp.clone());
@@ -1925,26 +1843,27 @@ impl Program {
                         self.do_throw(sexp.clone(), &l, &hash);
                     }
                 }
-                SExp::Nil(l) => self.load_atom(sexp.clone(), l, &hash, &[]),
-                SExp::Atom(l, v) => {
+                DebugSExpValue::Nil(l) => self.load_atom(sexp.clone(), &l, &hash, &[]),
+                DebugSExpValue::Atom(l, v) => {
                     if v.is_empty() {
-                        return self.load_atom(sexp.clone(), l, &hash, &[]);
+                        return self.load_atom(sexp.clone(), &l, &hash, &[]);
                     }
-                    self.env_select(sexp.clone(), l, &hash, v);
+                    self.env_select(sexp.clone(), &l, &hash, &v);
                 }
-                SExp::QuotedString(l, _, v) => {
+                DebugSExpValue::QuotedString(l, _, v) => {
                     if v.is_empty() {
-                        return self.load_atom(sexp.clone(), l, &hash, &[]);
+                        return self.load_atom(sexp.clone(), &l, &hash, &[]);
                     }
-                    self.env_select(sexp.clone(), l, &hash, v);
+                    self.env_select(sexp.clone(), &l, &hash, &v);
                 }
-                SExp::Integer(l, i) => {
-                    let v = bigint_to_bytes_clvm(&i);
-                    let v_ref = v.data();
-                    if v_ref.is_empty() {
-                        return self.load_atom(sexp.clone(), l, &hash, &[]);
+                DebugSExpValue::Integer(_, _) => {
+                    let (l, v) = sexp
+                        .atom_bytes()
+                        .expect("non-cons debug sexp should atomize");
+                    if v.is_empty() {
+                        return self.load_atom(sexp.clone(), &l, &hash, &[]);
                     }
-                    self.env_select(sexp.clone(), l, &hash, v_ref);
+                    self.env_select(sexp.clone(), &l, &hash, &v);
                 }
             }
 
@@ -1970,8 +1889,8 @@ impl Program {
     }
 
     fn start_insns(&mut self) {
-        let srcloc = Srcloc::start("*prolog*");
-        let source_sexp = Rc::new(SExp::Atom(srcloc.clone(), b"prolog".to_vec()));
+        let srcloc = debug_start_loc("*prolog*");
+        let source_sexp = T::atom(srcloc.clone(), b"prolog");
         for i in &[
             Instr::Section(".text".to_string()),
             Instr::Align4,
@@ -1990,8 +1909,8 @@ impl Program {
     }
 
     fn finish_insns(&mut self) -> Result<(), String> {
-        let srcloc = Srcloc::start("*epilog*");
-        let source_sexp = Rc::new(SExp::Atom(srcloc.clone(), b"epilog".to_vec()));
+        let srcloc = debug_start_loc("*epilog*");
+        let source_sexp = T::atom(srcloc.clone(), b"epilog");
         let mut constants = HashMap::new();
         swap(&mut constants, &mut self.constants);
 
@@ -2244,8 +2163,8 @@ impl Program {
         program: HashMap<String, Srcloc>,
         filename: &str,
         elf_output: &str,
-        sexp: Rc<SExp>,
-        env: Rc<SExp>,
+        sexp: T,
+        env: T,
         target_addr: u32,
         symbol_table: Rc<HashMap<String, String>>,
     ) -> Result<Self, String> {
@@ -2280,7 +2199,7 @@ impl Program {
 
         let dwarf_builder =
             DwarfBuilder::new(filename, elf_output, target_addr, symbol_table.clone());
-        let mut p: Program = Program {
+        let mut p: Program<T> = Program {
             program,
             finished_insns: Vec::new(),
             first_label: Default::default(),
@@ -2302,7 +2221,7 @@ impl Program {
         };
 
         p.symbol_table = symbol_table;
-        let loc = Srcloc::start("*env*");
+        let loc = debug_start_loc("*env*");
         let envhash = sha256tree(env.clone());
         for (remap_hash, name, remap_sexp) in remap_hashes.into_iter() {
             let remap_hash_hex = hex::encode(&remap_hash);

--- a/src/compiler/debug/armjit/emu_stub.rs
+++ b/src/compiler/debug/armjit/emu_stub.rs
@@ -346,3 +346,117 @@ impl CallbackGdbStub {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        hex_ascii, print_run_event, send_gdb_console_packet, stop_reason_from_event,
+        CallbackConnection,
+    };
+    use crate::compiler::debug::armjit::emu::{Event, RunEvent};
+    use gdbstub::common::Signal;
+    use gdbstub::conn::Connection;
+    use gdbstub::stub::SingleThreadStopReason;
+    use std::cell::RefCell;
+    use std::io;
+    use std::rc::Rc;
+
+    #[test]
+    fn hex_ascii_encodes_nibbles() {
+        assert_eq!(hex_ascii(0), b'0');
+        assert_eq!(hex_ascii(9), b'9');
+        assert_eq!(hex_ascii(10), b'a');
+        assert_eq!(hex_ascii(15), b'f');
+        assert_eq!(hex_ascii(16), b'0');
+    }
+
+    #[test]
+    fn send_gdb_console_packet_encodes_output_packet() {
+        let written = Rc::new(RefCell::new(Vec::new()));
+        let written_clone = written.clone();
+        let mut conn = CallbackConnection::new(Box::new(move |bytes| {
+            written_clone.borrow_mut().extend_from_slice(bytes);
+            Ok(())
+        }));
+
+        send_gdb_console_packet(&mut conn, "hi").expect("packet writes");
+
+        assert_eq!(written.borrow().as_slice(), b"$O68690a#bd");
+    }
+
+    #[test]
+    fn callback_connection_forwards_writes() {
+        let written = Rc::new(RefCell::new(Vec::new()));
+        let written_clone = written.clone();
+        let mut conn = CallbackConnection::new(Box::new(move |bytes| {
+            written_clone.borrow_mut().extend_from_slice(bytes);
+            Ok(())
+        }));
+
+        conn.write(b'a').expect("single byte write");
+        conn.write_all(b"bc").expect("buffer write");
+        conn.flush().expect("flush");
+
+        assert_eq!(written.borrow().as_slice(), b"abc");
+    }
+
+    #[test]
+    fn callback_connection_propagates_write_errors() {
+        let mut conn =
+            CallbackConnection::new(Box::new(|_| Err(io::Error::other("expected failure"))));
+
+        assert_eq!(
+            conn.write(b'a')
+                .expect_err("single byte write fails")
+                .kind(),
+            io::ErrorKind::Other
+        );
+        assert_eq!(
+            conn.write_all(b"abc")
+                .expect_err("buffer write fails")
+                .kind(),
+            io::ErrorKind::Other
+        );
+    }
+
+    #[test]
+    fn stop_reason_maps_emulator_events() {
+        assert!(matches!(
+            stop_reason_from_event(Event::Trap),
+            SingleThreadStopReason::Signal(Signal::SIGABRT)
+        ));
+        assert!(matches!(
+            stop_reason_from_event(Event::DoneStep),
+            SingleThreadStopReason::DoneStep
+        ));
+        assert!(matches!(
+            stop_reason_from_event(Event::Halted),
+            SingleThreadStopReason::Signal(Signal::SIGSTOP)
+        ));
+        assert!(matches!(
+            stop_reason_from_event(Event::Output),
+            SingleThreadStopReason::Signal(Signal::SIGUSR1)
+        ));
+        assert!(matches!(
+            stop_reason_from_event(Event::Break),
+            SingleThreadStopReason::SwBreak(())
+        ));
+        assert!(matches!(
+            stop_reason_from_event(Event::WatchWrite(0x1234)),
+            SingleThreadStopReason::Watch { addr: 0x1234, .. }
+        ));
+        assert!(matches!(
+            stop_reason_from_event(Event::WatchRead(0x5678)),
+            SingleThreadStopReason::Watch { addr: 0x5678, .. }
+        ));
+    }
+
+    #[test]
+    fn print_run_event_formats_for_logs() {
+        assert_eq!(print_run_event(&RunEvent::IncomingData), "IncomingData");
+        assert_eq!(
+            print_run_event(&RunEvent::Event(Event::Trap)),
+            "Event(Trap)"
+        );
+    }
+}

--- a/src/compiler/debug/mod.rs
+++ b/src/compiler/debug/mod.rs
@@ -1,13 +1,210 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::rc::Rc;
 
 use crate::classic::clvm::__type_compatibility__::{sha256, Bytes, BytesFromType};
+use crate::classic::clvm::casts::bigint_to_bytes_clvm;
 
-use crate::compiler::sexp::SExp;
-use crate::util::u8_from_number;
+use crate::compiler::sexp::{decode_string, parse_sexp, SExp};
+pub use crate::compiler::srcloc::Srcloc;
+use crate::util::{u8_from_number, Number};
+
+use sha2::{Digest, Sha256};
 
 pub mod armjit;
+
+#[derive(Clone, Debug)]
+pub enum DebugSExpValue<T> {
+    Nil(Srcloc),
+    Cons(Srcloc, T, T),
+    Integer(Srcloc, Number),
+    QuotedString(Srcloc, u8, Vec<u8>),
+    Atom(Srcloc, Vec<u8>),
+}
+
+pub trait DebugSExp: Clone + Display {
+    fn atom(loc: Srcloc, bytes: &[u8]) -> Self;
+    fn loc(&self) -> Srcloc;
+    fn atomize(&self) -> Self;
+    fn to_number(&self) -> Option<Number>;
+    fn proper_list(&self) -> Option<Vec<Self>>;
+    fn explode(&self) -> DebugSExpValue<Self>;
+
+    fn nilp(&self) -> bool {
+        matches!(self.atom_bytes(), Some((_, bytes)) if bytes.is_empty())
+    }
+
+    fn atom_bytes(&self) -> Option<(Srcloc, Vec<u8>)> {
+        match self.explode() {
+            DebugSExpValue::Cons(_, _, _) => None,
+            DebugSExpValue::Nil(loc) => Some((loc, Vec::new())),
+            DebugSExpValue::Atom(loc, bytes) => Some((loc, bytes)),
+            DebugSExpValue::QuotedString(loc, _, bytes) => Some((loc, bytes)),
+            DebugSExpValue::Integer(loc, number) => {
+                Some((loc, bigint_to_bytes_clvm(&number).data().clone()))
+            }
+        }
+    }
+}
+
+impl DebugSExp for Rc<SExp> {
+    fn atom(loc: Srcloc, bytes: &[u8]) -> Self {
+        Rc::new(SExp::Atom(loc, bytes.to_vec()))
+    }
+
+    fn loc(&self) -> Srcloc {
+        self.as_ref().loc()
+    }
+
+    fn atomize(&self) -> Self {
+        Rc::new(self.as_ref().atomize())
+    }
+
+    fn to_number(&self) -> Option<Number> {
+        self.as_ref().get_number().ok()
+    }
+
+    fn proper_list(&self) -> Option<Vec<Self>> {
+        let mut res = Vec::new();
+        let mut track = self.clone();
+
+        loop {
+            if track.nilp() {
+                return Some(res);
+            }
+
+            match track.explode() {
+                DebugSExpValue::Cons(_, left, right) => {
+                    res.push(left);
+                    track = right;
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    fn explode(&self) -> DebugSExpValue<Self> {
+        match self.as_ref() {
+            SExp::Nil(loc) => DebugSExpValue::Nil(loc.clone()),
+            SExp::Cons(loc, left, right) => {
+                DebugSExpValue::Cons(loc.clone(), left.clone(), right.clone())
+            }
+            SExp::Integer(loc, number) => DebugSExpValue::Integer(loc.clone(), number.clone()),
+            SExp::QuotedString(loc, quote, bytes) => {
+                DebugSExpValue::QuotedString(loc.clone(), *quote, bytes.clone())
+            }
+            SExp::Atom(loc, bytes) => DebugSExpValue::Atom(loc.clone(), bytes.clone()),
+        }
+    }
+}
+
+pub type ConcreteSExp = Rc<SExp>;
+
+pub fn debug_decode_string(v: &[u8]) -> String {
+    decode_string(v)
+}
+
+pub fn debug_parse_sexp<I>(start: Srcloc, input: I) -> Result<Vec<Rc<SExp>>, (Srcloc, String)>
+where
+    I: Iterator<Item = u8>,
+{
+    parse_sexp(start, input)
+}
+
+pub fn debug_start_loc(file: &str) -> Srcloc {
+    Srcloc::start(file)
+}
+
+pub fn debug_atom(loc: Srcloc, bytes: &[u8]) -> Rc<SExp> {
+    <Rc<SExp> as DebugSExp>::atom(loc, bytes)
+}
+
+pub fn debug_sha256tree<T: DebugSExp>(sexp: T) -> Vec<u8> {
+    match sexp.explode() {
+        DebugSExpValue::Cons(_, left, right) => {
+            let hash_left = debug_sha256tree(left);
+            let hash_right = debug_sha256tree(right);
+            let mut hasher = Sha256::new();
+            hasher.update([2]);
+            hasher.update(hash_left);
+            hasher.update(hash_right);
+            hasher.finalize().to_vec()
+        }
+        _ => {
+            let (_, bytes) = sexp
+                .atom_bytes()
+                .expect("non-cons debug sexp should atomize");
+            let mut hasher = Sha256::new();
+            hasher.update([1]);
+            hasher.update(bytes);
+            hasher.finalize().to_vec()
+        }
+    }
+}
+
+pub fn debug_truthy<T: DebugSExp>(sexp: T) -> bool {
+    !sexp.nilp()
+}
+
+pub fn debug_is_atom<T: DebugSExp>(sexp: T) -> Option<(Srcloc, Vec<u8>)> {
+    sexp.atom_bytes()
+}
+
+pub fn debug_is_wrapped_atom<T: DebugSExp>(sexp: T) -> Option<(Srcloc, Vec<u8>)> {
+    match sexp.explode() {
+        DebugSExpValue::Cons(_, left, right) => {
+            let (loc, atom) = match left.explode() {
+                DebugSExpValue::Atom(loc, atom) => (loc, atom),
+                _ => return None,
+            };
+            if debug_truthy(right) {
+                None
+            } else {
+                Some((loc, atom))
+            }
+        }
+        _ => None,
+    }
+}
+
+pub fn debug_dequote<T: DebugSExp>(sexp: T) -> Option<T> {
+    match sexp.explode() {
+        DebugSExpValue::Cons(_, left, right) => match left.explode() {
+            DebugSExpValue::Atom(_, atom) if atom == b"\x01" => Some(right),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn debug_collect_by_hash<T: DebugSExp>(hash: &[u8], sexp: T, matches: &mut Vec<T>) -> Vec<u8> {
+    if let DebugSExpValue::Cons(_, left, right) = sexp.explode() {
+        let hash_left = debug_collect_by_hash(hash, left, matches);
+        let hash_right = debug_collect_by_hash(hash, right, matches);
+        let mut hasher = Sha256::new();
+        hasher.update([2]);
+        hasher.update(hash_left);
+        hasher.update(hash_right);
+        let my_hash = hasher.finalize().to_vec();
+        if my_hash == hash {
+            matches.push(sexp);
+        }
+        my_hash
+    } else {
+        let the_hash = debug_sha256tree(sexp.clone());
+        if the_hash == hash {
+            matches.push(sexp);
+        }
+        the_hash
+    }
+}
+
+pub fn debug_find_all_by_hash<T: DebugSExp>(hash: &[u8], sexp: T) -> Vec<T> {
+    let mut matches = Vec::new();
+    debug_collect_by_hash(hash, sexp, &mut matches);
+    matches
+}
 
 /// Given an SExp and a transformation, make a map of the transformed subtrees of
 /// the given SExp in code that's indexed by treehash.  This will merge equivalent
@@ -171,4 +368,56 @@ pub fn relabel(code_map: &HashMap<String, SExp>, code: &SExp) -> SExp {
         swap_table.insert(ent.1.clone(), ent.0.clone());
     }
     relabel_inner_(code_map, &swap_table, code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        debug_dequote, debug_find_all_by_hash, debug_is_wrapped_atom, debug_sha256tree, DebugSExp,
+    };
+    use crate::compiler::sexp::{enlist, SExp};
+    use crate::compiler::srcloc::Srcloc;
+    use std::rc::Rc;
+
+    fn atom(bytes: &[u8]) -> Rc<SExp> {
+        Rc::new(SExp::Atom(Srcloc::start("*test*"), bytes.to_vec()))
+    }
+
+    #[test]
+    fn debug_sexp_proper_list_returns_original_nodes() {
+        let first = atom(b"a");
+        let second = atom(b"b");
+        let list = enlist(Srcloc::start("*test*"), &[first.clone(), second.clone()]);
+
+        let proper = list.proper_list().expect("proper list");
+
+        assert_eq!(proper, vec![first, second]);
+    }
+
+    #[test]
+    fn debug_sexp_helpers_match_expected_clvm_shapes() {
+        let quoted = Rc::new(SExp::Cons(
+            Srcloc::start("*test*"),
+            atom(&[1]),
+            atom(b"value"),
+        ));
+        assert_eq!(debug_dequote(quoted.clone()), Some(atom(b"value")));
+
+        let wrapped_atom = Rc::new(SExp::Cons(Srcloc::start("*test*"), atom(b"op"), atom(&[])));
+        assert_eq!(
+            debug_is_wrapped_atom(wrapped_atom),
+            Some((Srcloc::start("*test*"), b"op".to_vec()))
+        );
+    }
+
+    #[test]
+    fn debug_treehash_search_finds_matching_subtrees() {
+        let needle = atom(b"needle");
+        let haystack = enlist(Srcloc::start("*test*"), &[atom(b"left"), needle.clone()]);
+        let hash = debug_sha256tree(needle.clone());
+
+        let matches = debug_find_all_by_hash(&hash, haystack);
+
+        assert_eq!(matches, vec![needle]);
+    }
 }

--- a/src/compiler/debug/mod.rs
+++ b/src/compiler/debug/mod.rs
@@ -387,9 +387,12 @@ mod tests {
     fn debug_sexp_proper_list_returns_original_nodes() {
         let first = atom(b"a");
         let second = atom(b"b");
-        let list = enlist(Srcloc::start("*test*"), &[first.clone(), second.clone()]);
+        let list = Rc::new(enlist(
+            Srcloc::start("*test*"),
+            &[first.clone(), second.clone()],
+        ));
 
-        let proper = list.proper_list().expect("proper list");
+        let proper = DebugSExp::proper_list(&list).expect("proper list");
 
         assert_eq!(proper, vec![first, second]);
     }
@@ -413,7 +416,10 @@ mod tests {
     #[test]
     fn debug_treehash_search_finds_matching_subtrees() {
         let needle = atom(b"needle");
-        let haystack = enlist(Srcloc::start("*test*"), &[atom(b"left"), needle.clone()]);
+        let haystack = Rc::new(enlist(
+            Srcloc::start("*test*"),
+            &[atom(b"left"), needle.clone()],
+        ));
         let hash = debug_sha256tree(needle.clone());
 
         let matches = debug_find_all_by_hash(&hash, haystack);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a debug-facing S-expression trait facade with an implementation for `Rc<SExp>`.
- Move armjit sexp helper behavior behind `compiler::debug` wrappers.
- Make the ARM JIT debug code generic over the debug S-expression trait and remove direct `crate::compiler::*` imports outside `compiler::debug`.
- Add focused tests for the new debug sexp facade helpers.
- Fix the ARM debug CLI clippy warning that blocked the workspace clippy job.
- Install `gdb-multiarch` in the Npm workflow for the wasm ARM GDB stub test.
- Add focused unit coverage for ARM GDB stub helper behavior.

## Validation
- Installed `gdb-multiarch`
- `cargo fmt`
- `cargo check`
- `cargo test debug`
- `cargo test emu_stub`
- `cargo clippy --workspace -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dbca936-c555-41be-b094-778ec93a370e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dbca936-c555-41be-b094-778ec93a370e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

