### PR TITLE
Add rue debug ARM JIT compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,12 +1150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,9 +1489,7 @@ dependencies = [
 [[package]]
 name = "rue-ast"
 version = "0.8.4"
-source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
 dependencies = [
- "paste",
  "rue-parser",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "hkdf",
  "linked-hash-map",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -173,7 +173,7 @@ dependencies = [
  "hkdf",
  "linked-hash-map",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -202,7 +202,7 @@ checksum = "52463c56cdf35aac55ecb35ffc0a615f0780f33f144503957e83f5b1ad92da3c"
 dependencies = [
  "chia-sha2 0.28.2",
  "chia_streamable_macro 0.28.2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -213,7 +213,7 @@ checksum = "3517dcf2b743672c78339ef8d222fd4493ae48741c35dd5ffb2d9dba90417115"
 dependencies = [
  "chia-sha2 0.42.0",
  "chia_streamable_macro 0.42.0",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -222,7 +222,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6b807a9c04440d3f30b5534b84b462b996b34eee7fe0b7f8737ae6dfc6b9d4"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.104",
@@ -234,7 +234,7 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f85fb91e5ddba8003c4c4ad13c7914b1ff733d92136805c6566de227321d49"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.104",
@@ -258,6 +258,8 @@ dependencies = [
  "gimli",
  "hashlink",
  "hex",
+ "id-arena",
+ "indexmap 2.14.0",
  "indoc",
  "js-sys",
  "lazy_static",
@@ -270,6 +272,12 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "regex",
+ "rowan",
+ "rue-compiler",
+ "rue-diagnostic",
+ "rue-hir",
+ "rue-lir",
+ "rue-options",
  "serde",
  "serde_json",
  "sha2",
@@ -279,6 +287,47 @@ dependencies = [
  "unicode-segmentation",
  "wasm-bindgen",
  "yaml-rust2",
+]
+
+[[package]]
+name = "chialisp"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7eb5d3b740c534c601413b8c3c7ff4222626f8d54e27449392cfe215dc55479"
+dependencies = [
+ "binascii",
+ "chia-bls 0.42.0",
+ "clvmr",
+ "do-notation",
+ "getrandom 0.2.15",
+ "hashlink",
+ "hex",
+ "indoc",
+ "js-sys",
+ "lazy_static",
+ "num",
+ "num-bigint",
+ "num-traits",
+ "pyo3-build-config 0.24.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "yaml-rust2",
+]
+
+[[package]]
+name = "clvm-traits"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e74489df9233fdf7605d79032fe18f808ff33d7e69a9932db4c96ffd0e50e9"
+dependencies = [
+ "clvmr",
+ "num-bigint",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -302,7 +351,16 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "sha3",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -310,6 +368,21 @@ name = "const-oid"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
@@ -351,6 +424,29 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "rustc_version",
+ "syn 2.0.104",
+ "unicode-xid 0.2.6",
 ]
 
 [[package]]
@@ -458,7 +554,7 @@ dependencies = [
  "scroll",
  "string-interner",
  "target-lexicon 0.11.2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -494,6 +590,48 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "gdbstub"
@@ -562,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.1.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -611,9 +749,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -623,6 +761,12 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -676,6 +820,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,12 +856,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -709,6 +878,15 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -792,7 +970,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b797be749e5d7d013b3e18954049468c228841a5068ceb55dd9da23a300ecff6"
 dependencies = [
- "itertools",
+ "itertools 0.8.2",
  "lfsr-base",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -805,7 +983,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3a3a6a85a7aac81c9f94adc14ab565eaaac8fd91460d06b89e4dd93462cdf8"
 dependencies = [
- "itertools",
+ "itertools 0.8.2",
  "lfsr-base",
  "lfsr-instances",
  "proc-macro2 0.4.30",
@@ -893,6 +1071,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1169,12 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -1019,7 +1220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -1028,7 +1238,7 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -1226,6 +1436,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1449,184 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash",
+ "text-size",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.104",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rue-ast"
+version = "0.8.4"
+source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
+dependencies = [
+ "paste",
+ "rue-parser",
+]
+
+[[package]]
+name = "rue-compiler"
+version = "0.8.4"
+source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
+dependencies = [
+ "clvmr",
+ "hex",
+ "id-arena",
+ "include_dir",
+ "indexmap 2.14.0",
+ "log",
+ "num-bigint",
+ "num-traits",
+ "rowan",
+ "rue-ast",
+ "rue-diagnostic",
+ "rue-hir",
+ "rue-lexer",
+ "rue-lir",
+ "rue-options",
+ "rue-parser",
+ "rue-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rue-diagnostic"
+version = "0.8.4"
+source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rue-hir"
+version = "0.8.4"
+source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
+dependencies = [
+ "derive_more",
+ "hex",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "num-bigint",
+ "rue-diagnostic",
+ "rue-lir",
+ "rue-options",
+ "rue-types",
+]
+
+[[package]]
+name = "rue-lexer"
+version = "0.8.4"
+source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
+
+[[package]]
+name = "rue-lir"
+version = "0.8.4"
+source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
+dependencies = [
+ "chialisp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clvm-traits",
+ "clvmr",
+ "colored",
+ "id-arena",
+ "num-bigint",
+ "num-integer",
+ "sha2",
+ "sha3",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rue-options"
+version = "0.8.4"
+source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "toml",
+]
+
+[[package]]
+name = "rue-parser"
+version = "0.8.4"
+source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
+dependencies = [
+ "derive_more",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "num-derive",
+ "num-traits",
+ "rowan",
+ "rue-diagnostic",
+ "rue-lexer",
+]
+
+[[package]]
+name = "rue-types"
+version = "0.8.4"
+source = "git+https://github.com/xch-dev/rue.git#1a936999f411ff985b0b10170c09e9c82749b7fb"
+dependencies = [
+ "clvmr",
+ "derive_more",
+ "hex",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "rstest",
+ "rue-diagnostic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1295,6 +1689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1734,15 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1377,6 +1786,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spki"
@@ -1429,7 +1844,7 @@ checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "unicode-xid",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -1486,12 +1901,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1499,6 +1929,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
@@ -1515,10 +1956,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.13",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1526,10 +2000,37 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
- "toml_datetime",
- "winnow",
+ "indexmap 2.14.0",
+ "toml_datetime 0.6.5",
+ "winnow 0.5.30",
 ]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "typenum"
@@ -1539,9 +2040,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1554,6 +2055,12 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"
@@ -1732,6 +2239,21 @@ checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,14 @@ sha2 = "0.10.9"
 tempfile = "3.26.0"
 unicode-segmentation = "1.13.2"
 yaml-rust2 = "0.11.0"
+indexmap = "2.14.0"
+id-arena = "2.3.0"
+rue-compiler = { git = "https://github.com/xch-dev/rue.git", version = "0.8.4" }
+rue-hir = { git = "https://github.com/xch-dev/rue.git", version = "0.8.4" }
+rue-lir = { git = "https://github.com/xch-dev/rue.git", version = "0.8.4" }
+rue-options = { git = "https://github.com/xch-dev/rue.git", version = "0.8.4" }
+rue-diagnostic = { git = "https://github.com/xch-dev/rue.git", version = "0.8.4" }
+rowan = "0.16.1"
 
 [dependencies.pyo3]
 version = "0.25.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ rue-options = { git = "https://github.com/xch-dev/rue.git", version = "0.8.4" }
 rue-diagnostic = { git = "https://github.com/xch-dev/rue.git", version = "0.8.4" }
 rowan = "0.16.1"
 
+[patch."https://github.com/xch-dev/rue.git"]
+rue-ast = { path = "vendor/rue-ast" }
+
 [dependencies.pyo3]
 version = "0.25.1"
 features = ["abi3-py310", "extension-module"]

--- a/resources/tests/rue_factorial.rue
+++ b/resources/tests/rue_factorial.rue
@@ -1,0 +1,11 @@
+fn main(num: Int) -> Int {
+    factorial(num)
+}
+
+fn factorial(num: Int) -> Int {
+    if num > 1 {
+        num * factorial(num - 1)
+    } else {
+        1
+    }
+}

--- a/resources/tests/test_rue_sdc.sh
+++ b/resources/tests/test_rue_sdc.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./target/debug/armtx -o rue_sdc.elf ./resources/tests/rue_factorial.rue '(6)'

--- a/resources/tests/test_rue_sdc_gdb.sh
+++ b/resources/tests/test_rue_sdc_gdb.sh
@@ -5,4 +5,4 @@ if [ "x$1" != "x" ] ; then
 	ADDR="$1"
 fi
 
-gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break factorial" --ex "continue" --ex "print num" --ex "continue" --ex "quit 0" 2>&1
+gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *factorial" --ex "continue" --ex "print num" --ex "continue" --ex "quit 0" 2>&1

--- a/resources/tests/test_rue_sdc_gdb.sh
+++ b/resources/tests/test_rue_sdc_gdb.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+ADDR=127.0.0.1:9001
+if [ "x$1" != "x" ] ; then
+	ADDR="$1"
+fi
+
+gdb-multiarch --ex "set confirm off" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break factorial" --ex "continue" --ex "print num" --ex "continue" --ex "quit 0" 2>&1

--- a/resources/tests/test_rue_sdc_gdb.sh
+++ b/resources/tests/test_rue_sdc_gdb.sh
@@ -5,4 +5,4 @@ if [ "x$1" != "x" ] ; then
 	ADDR="$1"
 fi
 
-gdb-multiarch --batch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *(factorial + 28)" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "delete breakpoints" --ex "continue" 2>&1
+gdb-multiarch --batch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *(factorial + 28)" --ex "continue" --ex "print num" --ex "continue" --ex "print num" --ex "continue" --ex "print num" --ex "continue" --ex "print num" --ex "continue" --ex "print num" --ex "continue" --ex "print num" --ex "delete breakpoints" --ex "continue" 2>&1

--- a/resources/tests/test_rue_sdc_gdb.sh
+++ b/resources/tests/test_rue_sdc_gdb.sh
@@ -5,4 +5,4 @@ if [ "x$1" != "x" ] ; then
 	ADDR="$1"
 fi
 
-gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *factorial" --ex "continue" --ex "print num" --ex "continue" --ex "quit 0" 2>&1
+gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *(factorial + 4)" --ex "continue" --ex "print num" --ex "continue" --ex "quit 0" 2>&1

--- a/resources/tests/test_rue_sdc_gdb.sh
+++ b/resources/tests/test_rue_sdc_gdb.sh
@@ -5,4 +5,4 @@ if [ "x$1" != "x" ] ; then
 	ADDR="$1"
 fi
 
-gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *(factorial + 4)" --ex "continue" --ex "print num" --ex "continue" --ex "quit 0" 2>&1
+gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *(factorial + 4)" --ex "continue" --ex "backtrace" --ex "continue" --ex "quit 0" 2>&1

--- a/resources/tests/test_rue_sdc_gdb.sh
+++ b/resources/tests/test_rue_sdc_gdb.sh
@@ -5,4 +5,4 @@ if [ "x$1" != "x" ] ; then
 	ADDR="$1"
 fi
 
-gdb-multiarch --ex "set confirm off" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break factorial" --ex "continue" --ex "print num" --ex "continue" --ex "quit 0" 2>&1
+gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break factorial" --ex "continue" --ex "print num" --ex "continue" --ex "quit 0" 2>&1

--- a/resources/tests/test_rue_sdc_gdb.sh
+++ b/resources/tests/test_rue_sdc_gdb.sh
@@ -5,4 +5,4 @@ if [ "x$1" != "x" ] ; then
 	ADDR="$1"
 fi
 
-gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *(factorial + 28)" --ex "continue" --ex 'print (word*)$r7' --ex "delete breakpoints" --ex "continue" --ex "quit 0" 2>&1
+gdb-multiarch --batch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *(factorial + 28)" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "continue" --ex "print_clvm_path \$r7 3" --ex "delete breakpoints" --ex "continue" 2>&1

--- a/resources/tests/test_rue_sdc_gdb.sh
+++ b/resources/tests/test_rue_sdc_gdb.sh
@@ -5,4 +5,4 @@ if [ "x$1" != "x" ] ; then
 	ADDR="$1"
 fi
 
-gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *(factorial + 4)" --ex "continue" --ex "backtrace" --ex "continue" --ex "quit 0" 2>&1
+gdb-multiarch --ex "set confirm off" --ex "set architecture arm" --ex "file rue_sdc.elf" --ex "source support/gdb_print_sexp.py" --ex "handle SIGUSR1 noprint nostop pass" --ex "dir resources/tests" --ex "target remote ${ADDR}" --ex "break *(factorial + 28)" --ex "continue" --ex 'print (word*)$r7' --ex "delete breakpoints" --ex "continue" --ex "quit 0" 2>&1

--- a/src/classic/bins/armtx.rs
+++ b/src/classic/bins/armtx.rs
@@ -1,12 +1,18 @@
 use std::fs;
 use std::rc::Rc;
 
-use chialisp::compiler::debug::armjit::cmd::{compile_to_arm_elf, spin_up_emulation, Args};
+use chialisp::compiler::debug::armjit::cmd::{
+    compile_rue_to_arm_elf, compile_to_arm_elf, spin_up_emulation, Args,
+};
 
 fn run_arm_conversion() -> Result<(), String> {
     let args: Args = argh::from_env();
 
-    let arm_elf = compile_to_arm_elf(&args)?;
+    let arm_elf = if args.filename.ends_with(".rue") {
+        compile_rue_to_arm_elf(&args)?
+    } else {
+        compile_to_arm_elf(&args)?
+    };
 
     // copy all in-memory sections from the ELF file into system RAM
     (|| {

--- a/src/classic/bins/armtx.rs
+++ b/src/classic/bins/armtx.rs
@@ -17,7 +17,7 @@ fn run_arm_conversion() -> Result<(), String> {
     // copy all in-memory sections from the ELF file into system RAM
     (|| {
         fs::write(&args.output, &arm_elf.object_file)?;
-        fs::write(&format!("{}.clsp", args.output), &arm_elf.synthetic_source)
+        fs::write(format!("{}.clsp", args.output), &arm_elf.synthetic_source)
     })()
     .map_err(|e| format!("could not write elf file: {e:?}"))?;
 

--- a/src/compiler/debug/armjit/cmd.rs
+++ b/src/compiler/debug/armjit/cmd.rs
@@ -19,6 +19,7 @@ use crate::compiler::comptypes::CompilerOpts;
 use crate::compiler::debug::armjit::code::{ElfObject, Program, TARGET_ADDR};
 use crate::compiler::debug::armjit::emu::Emu;
 use crate::compiler::debug::armjit::emu_stub::{run_stub, start_stub};
+use crate::compiler::debug::armjit::rue::compile_rue_to_arm_elf as compile_rue_to_arm_elf_impl;
 use crate::compiler::debug::build_symbol_table_mut;
 use crate::compiler::dialect::AcceptedDialect;
 use crate::compiler::frontend::frontend;
@@ -69,6 +70,10 @@ pub fn compile_to_arm_elf(args: &Args) -> Result<ArmElfCompileOutput, String> {
         .map_err(|_| format!("error reading {}", args.filename))?;
 
     compile_to_arm_elf_from_source(args, argfile)
+}
+
+pub fn compile_rue_to_arm_elf(args: &Args) -> Result<ArmElfCompileOutput, String> {
+    compile_rue_to_arm_elf_impl(args)
 }
 
 pub fn compile_to_arm_elf_from_source(

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1507,7 +1507,7 @@ impl<T: DebugSExp> Program<T> {
                 for i in &[
                     Instr::Addi(Register::R(7), Register::R(4), 0),
                     Instr::Addi(Register::R(0), Register::R(7), 0),
-                    Instr::Bl(quoted_code.to_string()),
+                    Instr::Bl(code_comp),
                 ] {
                     self.push(source_sexp.clone(), loc, i.clone());
                 }

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1202,7 +1202,12 @@ impl DwarfBuilder {
                         (self.target_addr as usize + addr) as u64,
                     )),
                 );
-                sub_ent.set(DW_AT_high_pc, AttributeValue::Udata(size as u64));
+                sub_ent.set(
+                    DW_AT_high_pc,
+                    AttributeValue::Address(Address::Constant(
+                        (self.target_addr as usize + addr + size) as u64,
+                    )),
+                );
                 sub_ent.set(
                     DW_AT_frame_base,
                     AttributeValue::LocationListRef(loc_list_id),

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1069,6 +1069,14 @@ impl DwarfBuilder {
                 let argname = decode_string(&a);
                 let unit = self.dwarf.units.get_mut(self.unit_id);
 
+                let at_id = unit.add(subprogram_id, DW_TAG_formal_parameter);
+                let at_ent = unit.get_mut(at_id);
+                at_ent.set(
+                    DW_AT_name,
+                    AttributeValue::String(argname.as_bytes().to_vec()),
+                );
+                at_ent.set(DW_AT_type, AttributeValue::UnitRef(self.pointer_type));
+
                 let mut loclist = Vec::new();
 
                 for l in locations.iter() {
@@ -1091,14 +1099,7 @@ impl DwarfBuilder {
                 }
 
                 let loc_list_id = unit.locations.add(LocationList(loclist));
-
-                let at_id = unit.add(subprogram_id, DW_TAG_formal_parameter);
                 let at_ent = unit.get_mut(at_id);
-                at_ent.set(
-                    DW_AT_name,
-                    AttributeValue::String(argname.as_bytes().to_vec()),
-                );
-                at_ent.set(DW_AT_type, AttributeValue::UnitRef(self.pointer_type));
                 at_ent.set(DW_AT_location, AttributeValue::LocationListRef(loc_list_id));
 
                 /*
@@ -1202,7 +1203,12 @@ impl DwarfBuilder {
                         (self.target_addr as usize + addr) as u64,
                     )),
                 );
-                sub_ent.set(DW_AT_high_pc, AttributeValue::Udata(size as u64));
+                sub_ent.set(
+                    DW_AT_high_pc,
+                    AttributeValue::Address(Address::Constant(
+                        (self.target_addr as usize + addr + size) as u64,
+                    )),
+                );
                 sub_ent.set(
                     DW_AT_frame_base,
                     AttributeValue::LocationListRef(loc_list_id),

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -2040,13 +2040,6 @@ impl<T: DebugSExp> Program<T> {
             })
             .collect();
 
-        // Declare functions as imports and later link the labels they belong to.
-        for (label, funname) in self.function_symbols.iter() {
-            if label != funname && !self.label_is_taken(funname) {
-                decls.push((funname.clone(), Decl::function().into()));
-            }
-        }
-
         // Declare .debug_aranges
         decls.push((
             ".debug_aranges".to_string(),
@@ -2061,34 +2054,12 @@ impl<T: DebugSExp> Program<T> {
         let mut in_function = None;
 
         let mut produced_code = 0;
-        let mut defined_colloquial_names = HashSet::new();
-        let emitted_labels: HashSet<String> = self
-            .finished_insns
-            .iter()
-            .filter_map(|i| {
-                if let Instr::Globl(name) = i {
-                    Some(name.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
         let mut handle_def_end = |target_addr: u32,
-                                  defined_colloquial_names: &mut HashSet<String>,
                                   function_body: &mut Vec<u8>,
                                   in_function: &mut Option<String>|
          -> Result<(), String> {
             if let Some(defname) = in_function.as_ref() {
                 if !function_body.is_empty() {
-                    if let Some(funname) = self.function_symbols.get(defname) {
-                        if funname != defname
-                            && !emitted_labels.contains(funname)
-                            && !defined_colloquial_names.contains(funname)
-                        {
-                            obj.define(funname, vec![]).map_err(|e| format!("{e:?}"))?;
-                            defined_colloquial_names.insert(funname.clone());
-                        }
-                    }
                     eprintln!("obj define {defname}");
                     produced_code += function_body.len();
                     obj.define(defname, function_body.clone())
@@ -2102,12 +2073,7 @@ impl<T: DebugSExp> Program<T> {
 
         for i in self.finished_insns.iter() {
             if let Instr::Globl(name) = i {
-                handle_def_end(
-                    self.target_addr,
-                    &mut defined_colloquial_names,
-                    &mut function_body,
-                    &mut in_function,
-                )?;
+                handle_def_end(self.target_addr, &mut function_body, &mut in_function)?;
                 in_function = Some(name.to_string());
             }
 
@@ -2116,12 +2082,7 @@ impl<T: DebugSExp> Program<T> {
             }
         }
 
-        handle_def_end(
-            self.target_addr,
-            &mut defined_colloquial_names,
-            &mut function_body,
-            &mut in_function,
-        )?;
+        handle_def_end(self.target_addr, &mut function_body, &mut in_function)?;
         // Create .debug_aranges
         let mut debug_aranges: Vec<u8> = (0..0x20).map(|_| 0).collect();
         write_u32(&mut debug_aranges, 0, 0x1c);

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1169,7 +1169,7 @@ impl DwarfBuilder {
 
         eprintln!("get subprogram");
         let mut subprogram_names = vec![name.clone()];
-        if name != label && preferred_name.is_none() {
+        if name != label && preferred_name.is_none() && matched_signature.is_none() {
             // Keep a typed DIE for both the colloquial and emitted symbol names so
             // either one resolves to the same pointer return type in debuggers.
             subprogram_names.push(label.to_string());

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1777,7 +1777,9 @@ impl<T: DebugSExp> Program<T> {
                     preferred_name.as_deref(),
                 ) {
                     eprintln!("end block with function {function_name}");
-                    self.function_symbols.insert(label.clone(), function_name);
+                    if label == &function_name || !self.label_is_taken(&function_name) {
+                        self.function_symbols.insert(label.clone(), function_name);
+                    }
                 }
                 self.current_symbol = None;
                 self.current_symbol_name = None;

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1202,12 +1202,7 @@ impl DwarfBuilder {
                         (self.target_addr as usize + addr) as u64,
                     )),
                 );
-                sub_ent.set(
-                    DW_AT_high_pc,
-                    AttributeValue::Address(Address::Constant(
-                        (self.target_addr as usize + addr + size) as u64,
-                    )),
-                );
+                sub_ent.set(DW_AT_high_pc, AttributeValue::Udata(size as u64));
                 sub_ent.set(
                     DW_AT_frame_base,
                     AttributeValue::LocationListRef(loc_list_id),

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1362,6 +1362,114 @@ fn hexify(v: &[u8]) -> String {
     Bytes::new(Some(BytesFromType::Raw(v.to_vec()))).hex()
 }
 
+fn write_u16_le(buf: &mut [u8], offset: usize, value: u16) {
+    buf[offset] = (value & 0xff) as u8;
+    buf[offset + 1] = (value >> 8) as u8;
+}
+
+fn read_u32_le(buf: &[u8], offset: usize) -> u32 {
+    (buf[offset] as u32)
+        | ((buf[offset + 1] as u32) << 8)
+        | ((buf[offset + 2] as u32) << 16)
+        | ((buf[offset + 3] as u32) << 24)
+}
+
+fn mark_elf_executable(buf: &mut [u8], entry: u32) -> Result<(), String> {
+    const ELF_MAGIC: &[u8] = b"\x7fELF";
+    const EI_CLASS: usize = 4;
+    const EI_DATA: usize = 5;
+    const ELFCLASS32: u8 = 1;
+    const ELFDATA2LSB: u8 = 1;
+    const E_TYPE: usize = 16;
+    const E_ENTRY: usize = 24;
+    const ET_EXEC: u16 = 2;
+
+    if buf.len() < 52
+        || &buf[..ELF_MAGIC.len()] != ELF_MAGIC
+        || buf[EI_CLASS] != ELFCLASS32
+        || buf[EI_DATA] != ELFDATA2LSB
+    {
+        return Err("expected 32-bit little-endian ELF output".to_string());
+    }
+
+    write_u16_le(buf, E_TYPE, ET_EXEC);
+    write_u32(buf, E_ENTRY, entry);
+    Ok(())
+}
+
+fn add_elf_load_segment(buf: &mut Vec<u8>) -> Result<(), String> {
+    const E_PHOFF: usize = 28;
+    const E_SHOFF: usize = 32;
+    const E_PHENTSIZE: usize = 42;
+    const E_PHNUM: usize = 44;
+    const E_SHENTSIZE: usize = 46;
+    const E_SHNUM: usize = 48;
+    const SH_ADDR: usize = 12;
+    const SH_OFFSET: usize = 16;
+    const SH_SIZE: usize = 20;
+    const SH_FLAGS: usize = 8;
+    const SHF_ALLOC: u32 = 2;
+    const PT_LOAD: u32 = 1;
+    const PF_X: u32 = 1;
+    const PF_W: u32 = 2;
+    const PF_R: u32 = 4;
+
+    if buf.len() < 52 {
+        return Err("ELF header too short".to_string());
+    }
+
+    let shoff = read_u32_le(buf, E_SHOFF) as usize;
+    let shentsize = u16::from_le_bytes([buf[E_SHENTSIZE], buf[E_SHENTSIZE + 1]]) as usize;
+    let shnum = u16::from_le_bytes([buf[E_SHNUM], buf[E_SHNUM + 1]]) as usize;
+    let phentsize = u16::from_le_bytes([buf[E_PHENTSIZE], buf[E_PHENTSIZE + 1]]) as usize;
+    if phentsize != 32 {
+        return Err(format!(
+            "expected ELF32 program header size 32, got {phentsize}"
+        ));
+    }
+
+    let mut min_addr = u32::MAX;
+    let mut max_addr = 0_u32;
+    let mut min_offset = u32::MAX;
+    let mut max_offset = 0_u32;
+    for section_idx in 0..shnum {
+        let section = shoff + section_idx * shentsize;
+        if section + SH_SIZE + 4 > buf.len() {
+            return Err("section header table extends past ELF buffer".to_string());
+        }
+        let flags = read_u32_le(buf, section + SH_FLAGS);
+        if flags & SHF_ALLOC == 0 {
+            continue;
+        }
+
+        let addr = read_u32_le(buf, section + SH_ADDR);
+        let offset = read_u32_le(buf, section + SH_OFFSET);
+        let size = read_u32_le(buf, section + SH_SIZE);
+        min_addr = min_addr.min(addr);
+        max_addr = max_addr.max(addr + size);
+        min_offset = min_offset.min(offset);
+        max_offset = max_offset.max(offset + size);
+    }
+
+    if min_addr == u32::MAX {
+        return Err("no allocatable sections found for PT_LOAD".to_string());
+    }
+
+    let phoff = buf.len();
+    buf.resize(phoff + phentsize, 0);
+    write_u32(buf, phoff, PT_LOAD);
+    write_u32(buf, phoff + 4, min_offset);
+    write_u32(buf, phoff + 8, min_addr);
+    write_u32(buf, phoff + 12, min_addr);
+    write_u32(buf, phoff + 16, max_offset - min_offset);
+    write_u32(buf, phoff + 20, max_addr - min_addr);
+    write_u32(buf, phoff + 24, PF_R | PF_W | PF_X);
+    write_u32(buf, phoff + 28, 0x1000);
+    write_u32(buf, E_PHOFF, phoff as u32);
+    write_u16_le(buf, E_PHNUM, 1);
+    Ok(())
+}
+
 pub fn swi_print(register: usize, label: usize) -> usize {
     SWI_PRINT_EXPR | register << 4 | label << 8
 }
@@ -2113,6 +2221,7 @@ impl<T: DebugSExp> Program<T> {
         }
 
         let mut result_buf = obj.emit().map_err(|e| format!("obj emit {e:?}"))?;
+        mark_elf_executable(&mut result_buf, self.target_addr)?;
 
         // Patch up
         eprintln!("reload elf");
@@ -2129,6 +2238,7 @@ impl<T: DebugSExp> Program<T> {
             eprintln!("section {i} target {target:x} value {value:x}");
             write_u32(&mut result_buf, target, value);
         }
+        add_elf_load_segment(&mut result_buf)?;
 
         eprintln!("code succeeded");
         Ok(ElfObject {

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -2042,7 +2042,7 @@ impl<T: DebugSExp> Program<T> {
 
         // Declare functions as imports and later link the labels they belong to.
         for (label, funname) in self.function_symbols.iter() {
-            if label != funname {
+            if label != funname && !self.label_is_taken(funname) {
                 decls.push((funname.clone(), Decl::function().into()));
             }
         }

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -2062,6 +2062,17 @@ impl<T: DebugSExp> Program<T> {
 
         let mut produced_code = 0;
         let mut defined_colloquial_names = HashSet::new();
+        let emitted_labels: HashSet<String> = self
+            .finished_insns
+            .iter()
+            .filter_map(|i| {
+                if let Instr::Globl(name) = i {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
         let mut handle_def_end = |target_addr: u32,
                                   defined_colloquial_names: &mut HashSet<String>,
                                   function_body: &mut Vec<u8>,
@@ -2070,7 +2081,10 @@ impl<T: DebugSExp> Program<T> {
             if let Some(defname) = in_function.as_ref() {
                 if !function_body.is_empty() {
                     if let Some(funname) = self.function_symbols.get(defname) {
-                        if funname != defname && !defined_colloquial_names.contains(funname) {
+                        if funname != defname
+                            && !emitted_labels.contains(funname)
+                            && !defined_colloquial_names.contains(funname)
+                        {
                             obj.define(funname, vec![]).map_err(|e| format!("{e:?}"))?;
                             defined_colloquial_names.insert(funname.clone());
                         }

--- a/src/compiler/debug/armjit/code.rs
+++ b/src/compiler/debug/armjit/code.rs
@@ -1169,7 +1169,7 @@ impl DwarfBuilder {
 
         eprintln!("get subprogram");
         let mut subprogram_names = vec![name.clone()];
-        if name != label {
+        if name != label && preferred_name.is_none() {
             // Keep a typed DIE for both the colloquial and emitted symbol names so
             // either one resolves to the same pointer return type in debuggers.
             subprogram_names.push(label.to_string());

--- a/src/compiler/debug/armjit/mod.rs
+++ b/src/compiler/debug/armjit/mod.rs
@@ -6,3 +6,4 @@ pub mod emu;
 pub mod emu_stub;
 pub mod load;
 pub mod memory;
+pub mod rue;

--- a/src/compiler/debug/armjit/rue.rs
+++ b/src/compiler/debug/armjit/rue.rs
@@ -1501,10 +1501,6 @@ fn compile_main(
             continue;
         };
 
-        if let Some(loc) = symbol_locs.get(&symbol).cloned() {
-            program_locations.insert(name.clone(), loc);
-        }
-
         let mut body_arena = Arena::new();
         let mut body_locs = HashMap::new();
         let body_lir = {

--- a/src/compiler/debug/armjit/rue.rs
+++ b/src/compiler/debug/armjit/rue.rs
@@ -1539,10 +1539,6 @@ fn compile_main(
             continue;
         };
 
-        if let Some(loc) = symbol_locs.get(&symbol).cloned() {
-            program_locations.insert(name.clone(), loc);
-        }
-
         let Some(body_lir) = function_body_lirs.get(&symbol).copied() else {
             continue;
         };

--- a/src/compiler/debug/armjit/rue.rs
+++ b/src/compiler/debug/armjit/rue.rs
@@ -1,0 +1,1634 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use clvmr::Allocator;
+use id_arena::Arena;
+use indexmap::{IndexMap, IndexSet};
+use rue_compiler::{normalize_path, Compiler, FileTree, SyntaxItemKind};
+use rue_diagnostic::{DiagnosticSeverity, Source, SourceKind, SrcLoc};
+use rue_hir::{
+    BinaryOp, BindingSymbol, ConstantSymbol, Database, DependencyGraph, Environment, ExprStatement,
+    FunctionCall, FunctionKind, FunctionSymbol, Hir, HirId, IfStatement, PathError, Statement,
+    Symbol, SymbolId, UnaryOp,
+};
+use rue_lir::{bigint_atom, ClvmOp, Lir, LirId};
+use rue_options::find_project;
+
+use crate::classic::clvm_tools::binutils::assemble;
+use crate::compiler::clvm::convert_from_clvm_rs;
+use crate::compiler::debug::armjit::code::{ElfObject, Program, TARGET_ADDR};
+use crate::compiler::debug::{debug_decode_string, DebugSExp, DebugSExpValue, Srcloc};
+use crate::compiler::sexp::SExp;
+use crate::util::Number;
+
+use super::cmd::{Args, ArmElfCompileOutput};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RueSExp(Rc<SExp>);
+
+impl RueSExp {
+    fn new(sexp: SExp) -> Self {
+        Self(Rc::new(sexp))
+    }
+}
+
+impl fmt::Display for RueSExp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl DebugSExp for RueSExp {
+    fn atom(loc: Srcloc, bytes: &[u8]) -> Self {
+        Self::new(SExp::Atom(loc, bytes.to_vec()))
+    }
+
+    fn loc(&self) -> Srcloc {
+        self.0.loc()
+    }
+
+    fn atomize(&self) -> Self {
+        RueSExp(self.0.atomize())
+    }
+
+    fn to_number(&self) -> Option<Number> {
+        self.0.get_number().ok()
+    }
+
+    fn proper_list(&self) -> Option<Vec<Self>> {
+        let mut result = Vec::new();
+        let mut rest = self.clone();
+
+        loop {
+            if rest.nilp() {
+                return Some(result);
+            }
+
+            match rest.explode() {
+                DebugSExpValue::Cons(_, left, right) => {
+                    result.push(left);
+                    rest = right;
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    fn explode(&self) -> DebugSExpValue<Self> {
+        match self.0.as_ref() {
+            SExp::Nil(loc) => DebugSExpValue::Nil(loc.clone()),
+            SExp::Cons(loc, left, right) => {
+                DebugSExpValue::Cons(loc.clone(), RueSExp(left.clone()), RueSExp(right.clone()))
+            }
+            SExp::Integer(loc, number) => DebugSExpValue::Integer(loc.clone(), number.clone()),
+            SExp::QuotedString(loc, quote, bytes) => {
+                DebugSExpValue::QuotedString(loc.clone(), *quote, bytes.clone())
+            }
+            SExp::Atom(loc, bytes) => DebugSExpValue::Atom(loc.clone(), bytes.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum SymbolGroup {
+    Sequential(Vec<SymbolId>),
+    Tree(Environment),
+}
+
+impl SymbolGroup {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Sequential(symbols) => symbols.is_empty(),
+            Self::Tree(Environment::Nil) => true,
+            Self::Tree(_) => false,
+        }
+    }
+}
+
+struct DebugLowerer<'d, 'a, 'g> {
+    db: &'d mut Database,
+    arena: &'a mut Arena<Lir>,
+    graph: &'g DependencyGraph,
+    lir_locs: &'a mut HashMap<LirId, Srcloc>,
+    inline_symbols: Vec<HashMap<SymbolId, HirId>>,
+    options: rue_options::CompilerOptions,
+    main: SymbolId,
+    base_path: PathBuf,
+    symbol_locs: &'a HashMap<SymbolId, Srcloc>,
+    current_loc: Srcloc,
+}
+
+impl<'d, 'a, 'g> DebugLowerer<'d, 'a, 'g> {
+    fn new(
+        db: &'d mut Database,
+        arena: &'a mut Arena<Lir>,
+        graph: &'g DependencyGraph,
+        lir_locs: &'a mut HashMap<LirId, Srcloc>,
+        options: rue_options::CompilerOptions,
+        main: SymbolId,
+        base_path: PathBuf,
+        symbol_locs: &'a HashMap<SymbolId, Srcloc>,
+        fallback_loc: Srcloc,
+    ) -> Self {
+        Self {
+            db,
+            arena,
+            graph,
+            lir_locs,
+            inline_symbols: Vec::new(),
+            options,
+            main,
+            base_path,
+            symbol_locs,
+            current_loc: fallback_loc,
+        }
+    }
+
+    fn alloc(&mut self, lir: Lir, loc: Srcloc) -> LirId {
+        let id = self.arena.alloc(lir);
+        self.lir_locs.insert(id, loc);
+        id
+    }
+
+    fn alloc_here(&mut self, lir: Lir) -> LirId {
+        self.alloc(lir, self.current_loc.clone())
+    }
+
+    fn with_loc<R>(&mut self, loc: Srcloc, f: impl FnOnce(&mut Self) -> R) -> R {
+        let previous = self.current_loc.clone();
+        self.current_loc = loc;
+        let result = f(self);
+        self.current_loc = previous;
+        result
+    }
+
+    fn lower_symbol_value(&mut self, env: &Environment, symbol: SymbolId) -> LirId {
+        for inline_symbols in self.inline_symbols.iter().rev() {
+            if let Some(hir) = inline_symbols.get(&symbol) {
+                return self.lower_hir(env, *hir);
+            }
+        }
+
+        let loc = self
+            .symbol_locs
+            .get(&symbol)
+            .cloned()
+            .unwrap_or_else(|| self.current_loc.clone());
+        self.with_loc(loc, |lowerer| match lowerer.db.symbol(symbol).clone() {
+            Symbol::Unresolved | Symbol::Module(_) | Symbol::Parameter(_) | Symbol::Builtin(_) => {
+                unreachable!()
+            }
+            Symbol::Function(function) => lowerer.lower_function(env, symbol, function),
+            Symbol::Constant(constant) => lowerer.lower_constant(env, constant),
+            Symbol::Binding(binding) => lowerer.lower_binding(env, binding),
+        })
+    }
+
+    fn function_groups(
+        &mut self,
+        symbol: SymbolId,
+        function: &FunctionSymbol,
+    ) -> (Vec<SymbolGroup>, SymbolGroup) {
+        let captures: Vec<SymbolId> = self
+            .graph
+            .dependencies(symbol, true)
+            .into_iter()
+            .filter(|&symbol| !self.should_inline(symbol))
+            .collect();
+
+        let capture_groups = self.group_symbols(
+            captures.into_iter().collect(),
+            symbol != self.main,
+            !self.graph.is_closure(symbol),
+        );
+
+        let param_group = self.create_group(
+            function.parameters.values().copied().collect(),
+            function.kind == FunctionKind::BinaryTree
+                && !self.graph.is_closure(symbol)
+                && symbol != self.main,
+        );
+
+        (capture_groups, param_group)
+    }
+
+    fn lower_function(
+        &mut self,
+        parent_env: &Environment,
+        symbol: SymbolId,
+        function: FunctionSymbol,
+    ) -> LirId {
+        let (capture_groups, param_group) = self.function_groups(symbol, &function);
+
+        let mut function_env = Self::apply_group(
+            Environment::Nil,
+            &param_group,
+            function.nil_terminated && matches!(param_group, SymbolGroup::Sequential(_)),
+        );
+
+        for group in &capture_groups {
+            function_env = Self::apply_group(function_env, group, true);
+        }
+
+        let mut expr = self.lower_hir(&function_env, function.body);
+
+        if symbol == self.main {
+            let mut map = HashMap::new();
+
+            if self
+                .graph
+                .dependencies(symbol, true)
+                .iter()
+                .any(|dependency| *dependency == symbol)
+            {
+                let quoted = self.alloc_here(Lir::Quote(expr));
+                map.insert(symbol, quoted);
+                let reference = self.lower_symbol_reference(&function_env, symbol);
+                let entire_env = self.alloc_here(Lir::Path(1));
+                expr = self.alloc_here(Lir::Run(reference, entire_env));
+            }
+
+            for (i, group) in capture_groups.iter().enumerate().rev() {
+                expr = self.alloc_here(Lir::Quote(expr));
+
+                let mut bind_env = parent_env.clone();
+
+                for existing_group in capture_groups.iter().take(i) {
+                    bind_env = Self::apply_group(bind_env, existing_group, true);
+                }
+
+                let rest = if param_group.is_empty() {
+                    self.alloc_here(Lir::Atom(vec![]))
+                } else {
+                    self.alloc_here(Lir::Path(1))
+                };
+
+                let group_env =
+                    self.lower_group_environment(&bind_env, group, rest, false, Some(&map), true);
+
+                expr = self.alloc_here(Lir::Run(expr, group_env));
+            }
+
+            expr
+        } else {
+            self.alloc_here(Lir::Quote(expr))
+        }
+    }
+
+    fn lower_constant(&mut self, env: &Environment, constant: ConstantSymbol) -> LirId {
+        self.lower_hir(env, constant.value.hir)
+    }
+
+    fn lower_binding(&mut self, env: &Environment, binding: BindingSymbol) -> LirId {
+        self.lower_hir(env, binding.value.hir)
+    }
+
+    fn lower_hir(&mut self, env: &Environment, hir: HirId) -> LirId {
+        match self.db.hir(hir).clone() {
+            Hir::Unresolved => unreachable!(),
+            Hir::Nil => self.alloc_here(Lir::Atom(vec![])),
+            Hir::String(value) => self.alloc_here(Lir::Atom(value.as_bytes().to_vec())),
+            Hir::Int(value) => self.alloc_here(Lir::Atom(bigint_atom(value.clone()))),
+            Hir::Bool(value) => self.alloc_here(Lir::Atom(if value { vec![1] } else { vec![] })),
+            Hir::Bytes(atom) => self.alloc_here(Lir::Atom(atom)),
+            Hir::Pair(first, rest) => {
+                let first = self.lower_hir(env, first);
+                let rest = self.lower_hir(env, rest);
+                self.alloc_here(Lir::Cons(first, rest))
+            }
+            Hir::Reference(symbol) => self.lower_symbol(env, symbol, false),
+            Hir::Block(block) => self.lower_block(env, block.statements, block.body),
+            Hir::Lambda(lambda) => self.lower_symbol(env, lambda, true),
+            Hir::If(condition, then, else_, inline) => {
+                let condition = self.lower_hir(env, condition);
+                let then = self.lower_hir(env, then);
+                let else_ = self.lower_hir(env, else_);
+                self.alloc_here(Lir::If(condition, then, else_, inline))
+            }
+            Hir::FunctionCall(call) => self.lower_function_call(env, call),
+            Hir::Unary(op, hir) => {
+                let lir = self.lower_hir(env, hir);
+                match op {
+                    UnaryOp::Listp { can_be_truthy } => {
+                        self.alloc_here(Lir::Listp(lir, can_be_truthy))
+                    }
+                    UnaryOp::First => self.alloc_here(Lir::First(lir)),
+                    UnaryOp::Rest => self.alloc_here(Lir::Rest(lir)),
+                    UnaryOp::Strlen => self.alloc_here(Lir::Strlen(lir)),
+                    UnaryOp::Not => self.alloc_here(Lir::Not(lir)),
+                    UnaryOp::Neg => {
+                        let zero = self.alloc_here(Lir::Atom(vec![]));
+                        self.alloc_here(Lir::Sub(vec![zero, lir]))
+                    }
+                    UnaryOp::BitwiseNot => self.alloc_here(Lir::Lognot(lir)),
+                    UnaryOp::G1Negate => self.alloc_here(Lir::G1Negate(lir)),
+                    UnaryOp::G2Negate => self.alloc_here(Lir::G2Negate(lir)),
+                    UnaryOp::Sha256 => self.alloc_here(Lir::Sha256(vec![lir])),
+                    UnaryOp::Sha256Inline => self.alloc_here(Lir::Sha256Inline(vec![lir])),
+                    UnaryOp::Keccak256 => self.alloc_here(Lir::Keccak256(vec![lir])),
+                    UnaryOp::Keccak256Inline => self.alloc_here(Lir::Keccak256Inline(vec![lir])),
+                    UnaryOp::PubkeyForExp => self.alloc_here(Lir::PubkeyForExp(lir)),
+                }
+            }
+            Hir::Binary(op, left, right) => {
+                let left = self.lower_hir(env, left);
+                let right = self.lower_hir(env, right);
+                self.lower_binary(op, left, right)
+            }
+            Hir::CoinId(parent, puzzle, amount) => {
+                let parent = self.lower_hir(env, parent);
+                let puzzle = self.lower_hir(env, puzzle);
+                let amount = self.lower_hir(env, amount);
+                self.alloc_here(Lir::CoinId(parent, puzzle, amount))
+            }
+            Hir::Substr(hir, start, end) => {
+                let hir = self.lower_hir(env, hir);
+                let start = self.lower_hir(env, start);
+                let end = end.map(|end| self.lower_hir(env, end));
+                self.alloc_here(Lir::Substr(hir, start, end))
+            }
+            Hir::G1Map(data, dst) => {
+                let data = self.lower_hir(env, data);
+                let dst = dst.map(|dst| self.lower_hir(env, dst));
+                self.alloc_here(Lir::G1Map(data, dst))
+            }
+            Hir::G2Map(data, dst) => {
+                let data = self.lower_hir(env, data);
+                let dst = dst.map(|dst| self.lower_hir(env, dst));
+                self.alloc_here(Lir::G2Map(data, dst))
+            }
+            Hir::Modpow(base, exponent, modulus) => {
+                let base = self.lower_hir(env, base);
+                let exponent = self.lower_hir(env, exponent);
+                let modulus = self.lower_hir(env, modulus);
+                self.alloc_here(Lir::Modpow(base, exponent, modulus))
+            }
+            Hir::BlsPairingIdentity(args) => {
+                let args = args
+                    .into_iter()
+                    .map(|arg| self.lower_hir(env, arg))
+                    .collect();
+                self.alloc_here(Lir::BlsPairingIdentity(args))
+            }
+            Hir::BlsVerify(sig, args) => {
+                let sig = self.lower_hir(env, sig);
+                let args = args
+                    .into_iter()
+                    .map(|arg| self.lower_hir(env, arg))
+                    .collect();
+                self.alloc_here(Lir::BlsVerify(sig, args))
+            }
+            Hir::Secp256K1Verify(sig, pk, msg) => {
+                let sig = self.lower_hir(env, sig);
+                let pk = self.lower_hir(env, pk);
+                let msg = self.lower_hir(env, msg);
+                self.alloc_here(Lir::K1Verify(sig, pk, msg))
+            }
+            Hir::Secp256R1Verify(sig, pk, msg) => {
+                let sig = self.lower_hir(env, sig);
+                let pk = self.lower_hir(env, pk);
+                let msg = self.lower_hir(env, msg);
+                self.alloc_here(Lir::R1Verify(sig, pk, msg))
+            }
+            Hir::InfinityG1 => self.alloc_here(Lir::G1Add(vec![])),
+            Hir::InfinityG2 => self.alloc_here(Lir::G2Add(vec![])),
+            Hir::ClvmOp(op, args) => {
+                let args = self.lower_hir(env, args);
+                self.alloc_here(Lir::Op(op, args))
+            }
+        }
+    }
+
+    fn lower_binary(&mut self, op: BinaryOp, left: LirId, right: LirId) -> LirId {
+        match op {
+            BinaryOp::Add => self.alloc_here(Lir::Add(vec![left, right])),
+            BinaryOp::Sub => self.alloc_here(Lir::Sub(vec![left, right])),
+            BinaryOp::Mul => self.alloc_here(Lir::Mul(vec![left, right])),
+            BinaryOp::Div => self.alloc_here(Lir::Div(left, right)),
+            BinaryOp::Mod => self.alloc_here(Lir::Mod(left, right)),
+            BinaryOp::Divmod => self.alloc_here(Lir::Divmod(left, right)),
+            BinaryOp::Concat => self.alloc_here(Lir::Concat(vec![left, right])),
+            BinaryOp::G1Add => self.alloc_here(Lir::G1Add(vec![left, right])),
+            BinaryOp::G1Subtract => self.alloc_here(Lir::G1Subtract(vec![left, right])),
+            BinaryOp::G1Multiply => self.alloc_here(Lir::G1Multiply(left, right)),
+            BinaryOp::G2Add => self.alloc_here(Lir::G2Add(vec![left, right])),
+            BinaryOp::G2Subtract => self.alloc_here(Lir::G2Subtract(vec![left, right])),
+            BinaryOp::G2Multiply => self.alloc_here(Lir::G2Multiply(left, right)),
+            BinaryOp::BitwiseAnd => self.alloc_here(Lir::Logand(vec![left, right])),
+            BinaryOp::BitwiseOr => self.alloc_here(Lir::Logior(vec![left, right])),
+            BinaryOp::BitwiseXor => self.alloc_here(Lir::Logxor(vec![left, right])),
+            BinaryOp::RightLogicalShift => {
+                let zero = self.alloc_here(Lir::Atom(vec![]));
+                let neg = self.alloc_here(Lir::Sub(vec![zero, right]));
+                self.alloc_here(Lir::Lsh(left, neg))
+            }
+            BinaryOp::RightArithmeticShift => {
+                let zero = self.alloc_here(Lir::Atom(vec![]));
+                let neg = self.alloc_here(Lir::Sub(vec![zero, right]));
+                self.alloc_here(Lir::Ash(left, neg))
+            }
+            BinaryOp::LeftArithmeticShift => self.alloc_here(Lir::Ash(left, right)),
+            BinaryOp::Gt => self.alloc_here(Lir::Gt(left, right)),
+            BinaryOp::Lt => self.alloc_here(Lir::Gt(right, left)),
+            BinaryOp::Gte => {
+                let gt = self.alloc_here(Lir::Gt(left, right));
+                let eq = self.alloc_here(Lir::Eq(left, right));
+                self.alloc_here(Lir::Any(vec![gt, eq]))
+            }
+            BinaryOp::Lte => {
+                let lt = self.alloc_here(Lir::Gt(right, left));
+                let eq = self.alloc_here(Lir::Eq(left, right));
+                self.alloc_here(Lir::Any(vec![lt, eq]))
+            }
+            BinaryOp::GtBytes => self.alloc_here(Lir::GtBytes(left, right)),
+            BinaryOp::LtBytes => self.alloc_here(Lir::GtBytes(right, left)),
+            BinaryOp::GteBytes => {
+                let gt = self.alloc_here(Lir::GtBytes(left, right));
+                let eq = self.alloc_here(Lir::Eq(left, right));
+                self.alloc_here(Lir::Any(vec![gt, eq]))
+            }
+            BinaryOp::LteBytes => {
+                let lt = self.alloc_here(Lir::GtBytes(right, left));
+                let eq = self.alloc_here(Lir::Eq(left, right));
+                self.alloc_here(Lir::Any(vec![lt, eq]))
+            }
+            BinaryOp::Eq => self.alloc_here(Lir::Eq(left, right)),
+            BinaryOp::Ne => {
+                let eq = self.alloc_here(Lir::Eq(left, right));
+                self.alloc_here(Lir::Not(eq))
+            }
+            BinaryOp::And => {
+                let true_atom = self.alloc_here(Lir::Atom(vec![1]));
+                let false_atom = self.alloc_here(Lir::Atom(vec![]));
+                let right = self.alloc_here(Lir::If(right, true_atom, false_atom, false));
+                self.alloc_here(Lir::If(left, right, false_atom, false))
+            }
+            BinaryOp::Or => {
+                let true_atom = self.alloc_here(Lir::Atom(vec![1]));
+                let false_atom = self.alloc_here(Lir::Atom(vec![]));
+                let right = self.alloc_here(Lir::If(right, true_atom, false_atom, false));
+                self.alloc_here(Lir::If(left, true_atom, right, false))
+            }
+            BinaryOp::All => self.alloc_here(Lir::All(vec![left, right])),
+            BinaryOp::Any => self.alloc_here(Lir::Any(vec![left, right])),
+        }
+    }
+
+    fn lower_function_call(&mut self, env: &Environment, call: FunctionCall) -> LirId {
+        if let Some((symbol, function)) = match self.db.hir(call.function).clone() {
+            Hir::Reference(symbol) => match self.db.symbol(symbol).clone() {
+                Symbol::Function(function) => Some((symbol, function)),
+                _ => None,
+            },
+            _ => None,
+        } {
+            let mut args = HashMap::new();
+
+            if function.nil_terminated {
+                for (i, arg) in call.args.into_iter().enumerate() {
+                    args.insert(function.parameters[i], arg);
+                }
+            } else {
+                let mut arg_iter = call.args.into_iter().enumerate();
+
+                for (i, arg) in (&mut arg_iter).take(function.parameters.len() - 1) {
+                    args.insert(function.parameters[i], arg);
+                }
+
+                let mut last_arg = self.db.alloc_hir(Hir::Nil);
+
+                for (i, (_, arg)) in arg_iter.rev().enumerate() {
+                    if i == 0 && !call.nil_terminated {
+                        last_arg = arg;
+                    } else {
+                        last_arg = self.db.alloc_hir(Hir::Pair(arg, last_arg));
+                    }
+                }
+
+                if let Some(last_param) = function.parameters.last() {
+                    args.insert(*last_param.1, last_arg);
+                }
+            }
+
+            if self.should_inline(symbol) {
+                self.inline_symbols.push(args);
+                let result = self.lower_hir(env, function.body);
+                self.inline_symbols.pop().unwrap();
+                return result;
+            }
+
+            let (capture_groups, param_group) = self.function_groups(symbol, &function);
+            let function_lir = self.lower_symbol_reference(env, symbol);
+            let rest = self.alloc_here(Lir::Atom(vec![]));
+
+            let mut lir_args = HashMap::new();
+            for (symbol, hir) in &args {
+                lir_args.insert(*symbol, self.lower_hir(env, *hir));
+            }
+
+            let mut arg_env = self.lower_group_environment(
+                env,
+                &param_group,
+                rest,
+                false,
+                Some(&lir_args),
+                function.nil_terminated && matches!(param_group, SymbolGroup::Sequential(_)),
+            );
+
+            for group in &capture_groups {
+                arg_env = self.lower_group_environment(env, group, arg_env, true, None, true);
+            }
+
+            return self.alloc_here(Lir::Run(function_lir, arg_env));
+        }
+
+        let function = self.lower_hir(env, call.function);
+        let mut args = Vec::new();
+
+        for arg in call.args {
+            args.push(self.lower_hir(env, arg));
+        }
+
+        let mut env = self.alloc_here(Lir::Atom(Vec::new()));
+
+        for (i, &arg) in args.iter().rev().enumerate() {
+            if i == 0 && !call.nil_terminated {
+                env = arg;
+            } else {
+                env = self.alloc_here(Lir::Cons(arg, env));
+            }
+        }
+
+        self.alloc_here(Lir::Run(function, env))
+    }
+
+    fn lower_symbol_reference(&mut self, env: &Environment, symbol: SymbolId) -> LirId {
+        for inline_symbols in self.inline_symbols.iter().rev() {
+            if let Some(hir) = inline_symbols.get(&symbol) {
+                return self.lower_hir(env, *hir);
+            }
+        }
+
+        self.lower_path(env, symbol)
+    }
+
+    fn lower_symbol(&mut self, env: &Environment, symbol: SymbolId, is_lambda: bool) -> LirId {
+        let mut reference = if self.should_inline(symbol) || is_lambda {
+            self.lower_symbol_value(env, symbol)
+        } else {
+            self.lower_symbol_reference(env, symbol)
+        };
+
+        if let Symbol::Function(function) = self.db.symbol(symbol).clone() {
+            let captures: Vec<SymbolId> = self
+                .graph
+                .dependencies(symbol, true)
+                .into_iter()
+                .filter(|&symbol| !self.should_inline(symbol))
+                .collect();
+
+            let mut refs = Vec::new();
+            for capture in captures {
+                refs.push(self.lower_symbol_reference(env, capture));
+            }
+
+            reference = self.alloc_here(Lir::Closure(
+                reference,
+                refs,
+                !function.parameters.is_empty(),
+            ));
+        }
+
+        reference
+    }
+
+    fn lower_path(&mut self, env: &Environment, symbol: SymbolId) -> LirId {
+        self.alloc_here(Lir::Path(env.path(symbol).unwrap_or_else(
+            |error| match error {
+                PathError::SymbolNotFound => panic!(
+                    "clvm path in environment not found for symbol {}",
+                    self.db.debug_symbol(symbol)
+                ),
+                PathError::PathTooLarge => panic!(
+                    "calculated clvm path too large for symbol {}",
+                    self.db.debug_symbol(symbol)
+                ),
+            },
+        )))
+    }
+
+    fn lower_block(
+        &mut self,
+        env: &Environment,
+        mut stmts: Vec<Statement>,
+        body: Option<HirId>,
+    ) -> LirId {
+        if !self.options.debug_symbols {
+            stmts.retain(|stmt| !matches!(stmt, Statement::Debug(..)));
+        }
+
+        let Some(stmt) = stmts.first().cloned() else {
+            return if let Some(body) = body {
+                self.lower_hir(env, body)
+            } else {
+                self.alloc_here(Lir::Atom(vec![]))
+            };
+        };
+
+        match stmt {
+            Statement::Let(_) => self.lower_let_stmts(env, stmts, body),
+            Statement::Return(hir) => self.lower_block(env, vec![], Some(hir)),
+            Statement::Assert(condition, srcloc) => {
+                self.lower_assert(env, stmts, condition, srcloc, body)
+            }
+            Statement::Expr(stmt) => self.lower_expr_stmts(env, stmt, stmts, body),
+            Statement::Raise(hir, srcloc) => self.lower_raise(env, hir, srcloc),
+            Statement::If(stmt) => self.lower_if(env, stmts, stmt, body),
+            Statement::Debug(hir, srcloc) => self.lower_debug(env, stmts, hir, srcloc, body),
+        }
+    }
+
+    fn lower_let_stmts(
+        &mut self,
+        env: &Environment,
+        mut stmts: Vec<Statement>,
+        body: Option<HirId>,
+    ) -> LirId {
+        let mut symbols = IndexSet::new();
+
+        while let Some(Statement::Let(symbol)) = stmts.first() {
+            symbols.insert(*symbol);
+            stmts.remove(0);
+        }
+
+        let binding_groups = self.group_symbols(symbols, false, true);
+        let mut body_env = env.clone();
+
+        for group in &binding_groups {
+            body_env = Self::apply_group(body_env, group, true);
+        }
+
+        let mut expr = self.lower_block(&body_env, stmts, body);
+
+        for (i, group) in binding_groups.iter().enumerate().rev() {
+            expr = self.alloc_here(Lir::Quote(expr));
+            let mut bind_env = env.clone();
+
+            for group in binding_groups.iter().take(i) {
+                bind_env = Self::apply_group(bind_env, group, true);
+            }
+
+            let rest = self.alloc_here(Lir::Path(1));
+            let group_env = self.lower_group_environment(&bind_env, group, rest, false, None, true);
+            expr = self.alloc_here(Lir::Run(expr, group_env));
+        }
+
+        expr
+    }
+
+    fn lower_group_environment(
+        &mut self,
+        env: &Environment,
+        group: &SymbolGroup,
+        rest: LirId,
+        by_reference: bool,
+        map: Option<&HashMap<SymbolId, LirId>>,
+        include_rest: bool,
+    ) -> LirId {
+        match group {
+            SymbolGroup::Sequential(symbols) => {
+                let mut result = rest;
+
+                for (i, &symbol) in symbols.iter().rev().enumerate() {
+                    let value = if let Some(lir) = map.and_then(|map| map.get(&symbol)) {
+                        *lir
+                    } else if by_reference {
+                        self.lower_symbol_reference(env, symbol)
+                    } else {
+                        self.lower_symbol_value(env, symbol)
+                    };
+                    if !include_rest && i == 0 {
+                        result = value;
+                    } else {
+                        result = self.alloc_here(Lir::Cons(value, result));
+                    }
+                }
+
+                result
+            }
+            SymbolGroup::Tree(tree) => {
+                let tree = self.lower_tree(env, tree, by_reference, map);
+                if include_rest {
+                    self.alloc_here(Lir::Cons(tree, rest))
+                } else {
+                    tree
+                }
+            }
+        }
+    }
+
+    fn lower_tree(
+        &mut self,
+        env: &Environment,
+        tree: &Environment,
+        by_reference: bool,
+        map: Option<&HashMap<SymbolId, LirId>>,
+    ) -> LirId {
+        match tree {
+            Environment::Nil => self.alloc_here(Lir::Atom(vec![])),
+            Environment::Leaf(symbol) => {
+                if let Some(lir) = map.and_then(|map| map.get(symbol)) {
+                    *lir
+                } else if by_reference {
+                    self.lower_symbol_reference(env, *symbol)
+                } else {
+                    self.lower_symbol_value(env, *symbol)
+                }
+            }
+            Environment::Pair(first, rest) => {
+                let first = self.lower_tree(env, first, by_reference, map);
+                let rest = self.lower_tree(env, rest, by_reference, map);
+                self.alloc_here(Lir::Cons(first, rest))
+            }
+        }
+    }
+
+    fn lower_assert(
+        &mut self,
+        env: &Environment,
+        mut stmts: Vec<Statement>,
+        condition: HirId,
+        srcloc: SrcLoc,
+        body: Option<HirId>,
+    ) -> LirId {
+        stmts.remove(0);
+        let loc = rue_srcloc_to_chialisp(&srcloc);
+        self.with_loc(loc, |lowerer| {
+            let raise = if lowerer.options.debug_symbols {
+                let error = lowerer.alloc_here(Lir::Atom(
+                    format!("assertion failed at {}", srcloc.display(&lowerer.base_path))
+                        .into_bytes(),
+                ));
+                vec![error]
+            } else {
+                vec![]
+            };
+
+            let condition = lowerer.lower_hir(env, condition);
+            let then_branch = lowerer.lower_block(env, stmts, body);
+            let else_branch = lowerer.alloc_here(Lir::Raise(raise));
+            lowerer.alloc_here(Lir::If(condition, then_branch, else_branch, false))
+        })
+    }
+
+    fn lower_raise(&mut self, env: &Environment, hir: Option<HirId>, srcloc: SrcLoc) -> LirId {
+        let loc = rue_srcloc_to_chialisp(&srcloc);
+        self.with_loc(loc, |lowerer| {
+            if !lowerer.options.debug_symbols {
+                return lowerer.alloc_here(Lir::Raise(vec![]));
+            }
+
+            let error = lowerer.alloc_here(Lir::Atom(
+                format!("raise called at {}", srcloc.display(&lowerer.base_path)).into_bytes(),
+            ));
+            let lir = hir.map(|hir| lowerer.lower_hir(env, hir));
+            let mut args = vec![error];
+
+            if let Some(hir) = lir {
+                args.push(hir);
+            }
+
+            lowerer.alloc_here(Lir::Raise(args))
+        })
+    }
+
+    fn lower_debug(
+        &mut self,
+        env: &Environment,
+        mut stmts: Vec<Statement>,
+        value: HirId,
+        srcloc: SrcLoc,
+        body: Option<HirId>,
+    ) -> LirId {
+        stmts.remove(0);
+        let loc = rue_srcloc_to_chialisp(&srcloc);
+        self.with_loc(loc, |lowerer| {
+            let rest = lowerer.lower_block(env, stmts, body);
+            let value = lowerer.lower_hir(env, value);
+            let print =
+                lowerer.alloc_here(Lir::DebugPrint(srcloc.display(&lowerer.base_path), value));
+            let nil = lowerer.alloc_here(Lir::Atom(vec![]));
+            lowerer.alloc_here(Lir::If(print, nil, rest, false))
+        })
+    }
+
+    fn lower_if(
+        &mut self,
+        env: &Environment,
+        mut stmts: Vec<Statement>,
+        stmt: IfStatement,
+        body: Option<HirId>,
+    ) -> LirId {
+        stmts.remove(0);
+        let condition = self.lower_hir(env, stmt.condition);
+        let then_branch = self.lower_hir(env, stmt.then);
+        let else_branch = self.lower_block(env, stmts, body);
+        self.alloc_here(Lir::If(condition, then_branch, else_branch, stmt.inline))
+    }
+
+    fn lower_expr_stmts(
+        &mut self,
+        env: &Environment,
+        stmt: ExprStatement,
+        mut stmts: Vec<Statement>,
+        body: Option<HirId>,
+    ) -> LirId {
+        if self.options.debug_symbols {
+            stmts.remove(0);
+
+            let rest = self.lower_block(env, stmts, body);
+            let value = self.lower_hir(env, stmt.hir);
+            let one = self.alloc_here(Lir::Atom(vec![1]));
+            return self.alloc_here(Lir::If(one, rest, value, true));
+        }
+
+        let mut ids = Vec::new();
+
+        while let Some(Statement::Expr(expr)) = stmts.first().cloned() {
+            ids.push((self.lower_hir(env, expr.hir), expr.always_nil));
+            stmts.remove(0);
+        }
+
+        let expr = self.lower_block(env, stmts, body);
+
+        if ids.is_empty() {
+            return expr;
+        }
+
+        let (condition, verifications) = if ids.len() == 1 {
+            let condition = self.alloc_here(Lir::Atom(vec![]));
+            (condition, ids[0].0)
+        } else if let Some(index) = ids.iter().position(|(_, always_nil)| *always_nil) {
+            let (condition, _) = ids.remove(index);
+            let id = if ids.len() == 1 {
+                ids[0].0
+            } else {
+                self.alloc_here(Lir::All(ids.iter().map(|(id, _)| *id).collect()))
+            };
+            (condition, id)
+        } else {
+            let condition = self.alloc_here(Lir::Atom(vec![]));
+            let id = if ids.len() == 1 {
+                ids[0].0
+            } else {
+                self.alloc_here(Lir::All(ids.iter().map(|(id, _)| *id).collect()))
+            };
+            (condition, id)
+        };
+
+        self.alloc_here(Lir::If(condition, verifications, expr, true))
+    }
+
+    fn group_symbols(
+        &mut self,
+        mut symbols: IndexSet<SymbolId>,
+        by_reference: bool,
+        is_tree: bool,
+    ) -> Vec<SymbolGroup> {
+        let mut groups = Vec::new();
+
+        while !symbols.is_empty() {
+            let mut group = Vec::new();
+            let remaining = symbols.clone();
+
+            symbols.retain(|&symbol| {
+                if self
+                    .graph
+                    .dependencies(symbol, true)
+                    .iter()
+                    .all(|symbol| !remaining.contains(symbol))
+                    || matches!(self.db.symbol(symbol), Symbol::Function(_))
+                    || by_reference
+                {
+                    if !self.should_inline(symbol) && self.graph.references(symbol) > 0 {
+                        group.push(symbol);
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+
+            if !group.is_empty() {
+                groups.push(self.create_group(group, is_tree));
+            }
+        }
+
+        groups
+    }
+
+    fn create_group(&self, symbols: Vec<SymbolId>, is_tree: bool) -> SymbolGroup {
+        if is_tree {
+            let mut referenced_symbols = IndexMap::new();
+
+            for symbol in symbols {
+                referenced_symbols.insert(symbol, self.graph.references(symbol));
+            }
+
+            SymbolGroup::Tree(Environment::tree(referenced_symbols))
+        } else {
+            SymbolGroup::Sequential(symbols)
+        }
+    }
+
+    fn apply_group(mut env: Environment, group: &SymbolGroup, include_rest: bool) -> Environment {
+        match group {
+            SymbolGroup::Sequential(symbols) => {
+                for (i, &symbol) in symbols.iter().rev().enumerate() {
+                    if i == 0 && !include_rest {
+                        env = Environment::Leaf(symbol);
+                    } else {
+                        env = Environment::Pair(Box::new(Environment::Leaf(symbol)), Box::new(env));
+                    }
+                }
+
+                env
+            }
+            SymbolGroup::Tree(tree) => {
+                if include_rest {
+                    Environment::Pair(Box::new(tree.clone()), Box::new(env))
+                } else {
+                    tree.clone()
+                }
+            }
+        }
+    }
+
+    fn should_inline(&self, symbol: SymbolId) -> bool {
+        if self
+            .inline_symbols
+            .iter()
+            .any(|symbols| symbols.contains_key(&symbol))
+        {
+            return true;
+        }
+
+        let references = self.graph.references(symbol);
+
+        match self.db.symbol(symbol) {
+            Symbol::Unresolved | Symbol::Module(_) | Symbol::Parameter(_) | Symbol::Builtin(_) => {
+                false
+            }
+            Symbol::Function(function) => {
+                if self.graph.dependencies(symbol, false).contains(&symbol) {
+                    return false;
+                }
+
+                if function.kind == FunctionKind::Inline {
+                    return true;
+                }
+
+                for (_, parameter) in &function.parameters {
+                    if self.graph.references(*parameter) > 1 {
+                        return false;
+                    }
+                }
+
+                references <= 1 && self.options.auto_inline
+            }
+            Symbol::Constant(constant) => {
+                if constant.inline {
+                    return true;
+                }
+
+                references <= 1 && self.options.auto_inline
+            }
+            Symbol::Binding(binding) => {
+                if binding.inline {
+                    return true;
+                }
+
+                references <= 1 && self.options.auto_inline
+            }
+        }
+    }
+}
+
+fn atom(loc: Srcloc, bytes: Vec<u8>) -> RueSExp {
+    RueSExp::new(SExp::Atom(loc, bytes))
+}
+
+fn nil(loc: Srcloc) -> RueSExp {
+    RueSExp::new(SExp::Nil(loc))
+}
+
+fn cons(loc: Srcloc, left: RueSExp, right: RueSExp) -> RueSExp {
+    RueSExp::new(SExp::Cons(loc, left.0, right.0))
+}
+
+fn pair(left: RueSExp, right: RueSExp) -> RueSExp {
+    let loc = left.loc().ext(&right.loc());
+    cons(loc, left, right)
+}
+
+fn list(loc: Srcloc, items: Vec<RueSExp>) -> RueSExp {
+    let mut result = nil(loc);
+    for item in items.into_iter().rev() {
+        result = pair(item, result);
+    }
+    result
+}
+
+fn op_list(loc: Srcloc, op: ClvmOp, args: Vec<RueSExp>) -> RueSExp {
+    let mut items = Vec::with_capacity(args.len() + 1);
+    items.push(atom(loc.clone(), op.to_atom()));
+    items.extend(args);
+    list(loc, items)
+}
+
+fn quote(loc: Srcloc, value: RueSExp) -> RueSExp {
+    cons(loc.clone(), atom(loc, ClvmOp::Quote.to_atom()), value)
+}
+
+fn codegen_debug(arena: &Arena<Lir>, locs: &HashMap<LirId, Srcloc>, lir: LirId) -> RueSExp {
+    let loc = locs
+        .get(&lir)
+        .cloned()
+        .unwrap_or_else(|| Srcloc::start("*rue*"));
+    match &arena[lir] {
+        Lir::Atom(bytes) => {
+            if bytes.is_empty() {
+                nil(loc)
+            } else {
+                quote(loc.clone(), atom(loc, bytes.clone()))
+            }
+        }
+        Lir::Quote(arg) => {
+            let arg = codegen_debug(arena, locs, *arg);
+            quote(loc, arg)
+        }
+        Lir::Path(path) => {
+            let mut bytes = bigint_atom((*path).into());
+            while !bytes.is_empty() && bytes[0] == 0 {
+                bytes = bytes[1..].to_vec();
+            }
+            atom(loc, bytes)
+        }
+        Lir::Run(callee, env) => op_list(
+            loc,
+            ClvmOp::Apply,
+            vec![
+                codegen_debug(arena, locs, *callee),
+                codegen_debug(arena, locs, *env),
+            ],
+        ),
+        Lir::Closure(function, captures, has_parameters) => {
+            let function = codegen_debug(arena, locs, *function);
+            let mut args = if *has_parameters {
+                quote(loc.clone(), atom(loc.clone(), vec![1]))
+            } else {
+                nil(loc.clone())
+            };
+
+            for capture in captures.iter().rev() {
+                let capture = codegen_debug(arena, locs, *capture);
+                args = op_list(
+                    loc.clone(),
+                    ClvmOp::Cons,
+                    vec![
+                        quote(loc.clone(), atom(loc.clone(), ClvmOp::Cons.to_atom())),
+                        op_list(
+                            loc.clone(),
+                            ClvmOp::Cons,
+                            vec![
+                                op_list(
+                                    loc.clone(),
+                                    ClvmOp::Cons,
+                                    vec![
+                                        quote(
+                                            loc.clone(),
+                                            atom(loc.clone(), ClvmOp::Quote.to_atom()),
+                                        ),
+                                        capture,
+                                    ],
+                                ),
+                                op_list(loc.clone(), ClvmOp::Cons, vec![args, nil(loc.clone())]),
+                            ],
+                        ),
+                    ],
+                );
+            }
+
+            op_list(
+                loc.clone(),
+                ClvmOp::Cons,
+                vec![
+                    quote(loc.clone(), atom(loc.clone(), ClvmOp::Apply.to_atom())),
+                    op_list(
+                        loc.clone(),
+                        ClvmOp::Cons,
+                        vec![
+                            op_list(
+                                loc.clone(),
+                                ClvmOp::Cons,
+                                vec![
+                                    quote(loc.clone(), atom(loc.clone(), ClvmOp::Quote.to_atom())),
+                                    function,
+                                ],
+                            ),
+                            op_list(loc.clone(), ClvmOp::Cons, vec![args, nil(loc.clone())]),
+                        ],
+                    ),
+                ],
+            )
+        }
+        Lir::First(arg) => op_list(loc, ClvmOp::First, vec![codegen_debug(arena, locs, *arg)]),
+        Lir::Rest(arg) => op_list(loc, ClvmOp::Rest, vec![codegen_debug(arena, locs, *arg)]),
+        Lir::Cons(first, rest) => op_list(
+            loc,
+            ClvmOp::Cons,
+            vec![
+                codegen_debug(arena, locs, *first),
+                codegen_debug(arena, locs, *rest),
+            ],
+        ),
+        Lir::Listp(arg, _) => op_list(loc, ClvmOp::Listp, vec![codegen_debug(arena, locs, *arg)]),
+        Lir::Add(args) => op_list_args(arena, locs, loc, ClvmOp::Add, args),
+        Lir::Sub(args) => op_list_args(arena, locs, loc, ClvmOp::Sub, args),
+        Lir::Mul(args) => op_list_args(arena, locs, loc, ClvmOp::Mul, args),
+        Lir::Div(first, second) => op_list_binary(arena, locs, loc, ClvmOp::Div, *first, *second),
+        Lir::Divmod(first, second) => {
+            op_list_binary(arena, locs, loc, ClvmOp::Divmod, *first, *second)
+        }
+        Lir::Mod(first, second) => op_list_binary(arena, locs, loc, ClvmOp::Mod, *first, *second),
+        Lir::Modpow(a, b, c) => op_list(
+            loc,
+            ClvmOp::Modpow,
+            vec![
+                codegen_debug(arena, locs, *a),
+                codegen_debug(arena, locs, *b),
+                codegen_debug(arena, locs, *c),
+            ],
+        ),
+        Lir::Eq(first, second) => op_list_binary(arena, locs, loc, ClvmOp::Eq, *first, *second),
+        Lir::Gt(first, second) => op_list_binary(arena, locs, loc, ClvmOp::Gt, *first, *second),
+        Lir::GtBytes(first, second) => {
+            op_list_binary(arena, locs, loc, ClvmOp::GtBytes, *first, *second)
+        }
+        Lir::Not(arg) => op_list(loc, ClvmOp::Not, vec![codegen_debug(arena, locs, *arg)]),
+        Lir::All(args) => op_list_args(arena, locs, loc, ClvmOp::All, args),
+        Lir::Any(args) => op_list_args(arena, locs, loc, ClvmOp::Any, args),
+        Lir::If(cond, then_lir, else_lir, inline) => {
+            let cond = codegen_debug(arena, locs, *cond);
+            let then_ptr = codegen_debug(arena, locs, *then_lir);
+            let else_ptr = codegen_debug(arena, locs, *else_lir);
+            if *inline {
+                op_list(loc, ClvmOp::If, vec![cond, then_ptr, else_ptr])
+            } else {
+                op_list(
+                    loc.clone(),
+                    ClvmOp::Apply,
+                    vec![
+                        op_list(
+                            loc.clone(),
+                            ClvmOp::If,
+                            vec![
+                                cond,
+                                quote(loc.clone(), then_ptr),
+                                quote(loc.clone(), else_ptr),
+                            ],
+                        ),
+                        atom(loc, vec![1]),
+                    ],
+                )
+            }
+        }
+        Lir::Raise(args) => op_list_args(arena, locs, loc, ClvmOp::Raise, args),
+        Lir::Concat(args) => op_list_args(arena, locs, loc, ClvmOp::Concat, args),
+        Lir::Strlen(arg) => op_list(loc, ClvmOp::Strlen, vec![codegen_debug(arena, locs, *arg)]),
+        Lir::Substr(arg, start, end) => {
+            let mut args = vec![
+                codegen_debug(arena, locs, *arg),
+                codegen_debug(arena, locs, *start),
+            ];
+            if let Some(end) = end {
+                args.push(codegen_debug(arena, locs, *end));
+            }
+            op_list(loc, ClvmOp::Substr, args)
+        }
+        Lir::Logand(args) => op_list_args(arena, locs, loc, ClvmOp::Logand, args),
+        Lir::Logior(args) => op_list_args(arena, locs, loc, ClvmOp::Logior, args),
+        Lir::Logxor(args) => op_list_args(arena, locs, loc, ClvmOp::Logxor, args),
+        Lir::Lognot(arg) => op_list(loc, ClvmOp::Lognot, vec![codegen_debug(arena, locs, *arg)]),
+        Lir::Ash(arg, shift) => op_list_binary(arena, locs, loc, ClvmOp::Ash, *arg, *shift),
+        Lir::Lsh(arg, shift) => op_list_binary(arena, locs, loc, ClvmOp::Lsh, *arg, *shift),
+        Lir::PubkeyForExp(arg) => op_list(
+            loc,
+            ClvmOp::PubkeyForExp,
+            vec![codegen_debug(arena, locs, *arg)],
+        ),
+        Lir::G1Add(args) => op_list_args(arena, locs, loc, ClvmOp::G1Add, args),
+        Lir::G1Subtract(args) => op_list_args(arena, locs, loc, ClvmOp::G1Subtract, args),
+        Lir::G1Multiply(first, second) => {
+            op_list_binary(arena, locs, loc, ClvmOp::G1Multiply, *first, *second)
+        }
+        Lir::G1Negate(arg) => op_list(
+            loc,
+            ClvmOp::G1Negate,
+            vec![codegen_debug(arena, locs, *arg)],
+        ),
+        Lir::G1Map(value, dst) => {
+            let mut args = vec![codegen_debug(arena, locs, *value)];
+            if let Some(dst) = dst {
+                args.push(codegen_debug(arena, locs, *dst));
+            }
+            op_list(loc, ClvmOp::G1Map, args)
+        }
+        Lir::G2Add(args) => op_list_args(arena, locs, loc, ClvmOp::G2Add, args),
+        Lir::G2Subtract(args) => op_list_args(arena, locs, loc, ClvmOp::G2Subtract, args),
+        Lir::G2Multiply(first, second) => {
+            op_list_binary(arena, locs, loc, ClvmOp::G2Multiply, *first, *second)
+        }
+        Lir::G2Negate(arg) => op_list(
+            loc,
+            ClvmOp::G2Negate,
+            vec![codegen_debug(arena, locs, *arg)],
+        ),
+        Lir::G2Map(value, dst) => {
+            let mut args = vec![codegen_debug(arena, locs, *value)];
+            if let Some(dst) = dst {
+                args.push(codegen_debug(arena, locs, *dst));
+            }
+            op_list(loc, ClvmOp::G2Map, args)
+        }
+        Lir::BlsPairingIdentity(args) => {
+            op_list_args(arena, locs, loc, ClvmOp::BlsPairingIdentity, args)
+        }
+        Lir::BlsVerify(arg, args) => {
+            let mut items = vec![codegen_debug(arena, locs, *arg)];
+            items.extend(args.iter().map(|arg| codegen_debug(arena, locs, *arg)));
+            op_list(loc, ClvmOp::BlsVerify, items)
+        }
+        Lir::Sha256(args) | Lir::Sha256Inline(args) => {
+            op_list_args(arena, locs, loc, ClvmOp::Sha256, args)
+        }
+        Lir::Keccak256(args) | Lir::Keccak256Inline(args) => {
+            op_list_args(arena, locs, loc, ClvmOp::Keccak256, args)
+        }
+        Lir::CoinId(parent, puzzle, amount) => op_list(
+            loc,
+            ClvmOp::CoinId,
+            vec![
+                codegen_debug(arena, locs, *parent),
+                codegen_debug(arena, locs, *puzzle),
+                codegen_debug(arena, locs, *amount),
+            ],
+        ),
+        Lir::K1Verify(pubkey, message, signature) => op_list(
+            loc,
+            ClvmOp::Secp256K1Verify,
+            vec![
+                codegen_debug(arena, locs, *pubkey),
+                codegen_debug(arena, locs, *message),
+                codegen_debug(arena, locs, *signature),
+            ],
+        ),
+        Lir::R1Verify(pubkey, message, signature) => op_list(
+            loc,
+            ClvmOp::Secp256R1Verify,
+            vec![
+                codegen_debug(arena, locs, *pubkey),
+                codegen_debug(arena, locs, *message),
+                codegen_debug(arena, locs, *signature),
+            ],
+        ),
+        Lir::Op(op, args) => {
+            let args = codegen_debug(arena, locs, *args);
+            op_list(
+                loc.clone(),
+                ClvmOp::Apply,
+                vec![
+                    op_list(
+                        loc.clone(),
+                        ClvmOp::Cons,
+                        vec![
+                            op_list(
+                                loc.clone(),
+                                ClvmOp::Cons,
+                                vec![
+                                    quote(loc.clone(), atom(loc.clone(), op.to_atom())),
+                                    nil(loc.clone()),
+                                ],
+                            ),
+                            args,
+                        ],
+                    ),
+                    nil(loc),
+                ],
+            )
+        }
+        Lir::DebugPrint(srcloc, value) => op_list(
+            loc.clone(),
+            ClvmOp::DebugPrint,
+            vec![
+                quote(loc.clone(), atom(loc.clone(), srcloc.as_bytes().to_vec())),
+                codegen_debug(arena, locs, *value),
+            ],
+        ),
+    }
+}
+
+fn op_list_binary(
+    arena: &Arena<Lir>,
+    locs: &HashMap<LirId, Srcloc>,
+    loc: Srcloc,
+    op: ClvmOp,
+    first: LirId,
+    second: LirId,
+) -> RueSExp {
+    op_list(
+        loc,
+        op,
+        vec![
+            codegen_debug(arena, locs, first),
+            codegen_debug(arena, locs, second),
+        ],
+    )
+}
+
+fn op_list_args(
+    arena: &Arena<Lir>,
+    locs: &HashMap<LirId, Srcloc>,
+    loc: Srcloc,
+    op: ClvmOp,
+    args: &[LirId],
+) -> RueSExp {
+    op_list(
+        loc,
+        op,
+        args.iter()
+            .map(|arg| codegen_debug(arena, locs, *arg))
+            .collect(),
+    )
+}
+
+fn rue_srcloc_to_chialisp(loc: &SrcLoc) -> Srcloc {
+    let start = loc.start();
+    let end = loc.end();
+    let file = loc.source.kind.display(Path::new("."));
+    let mut out = Srcloc::new(Rc::new(file), start.line + 1, start.col + 1);
+    out.until = Some(crate::compiler::srcloc::Until {
+        line: end.line + 1,
+        col: end.col + 1,
+    });
+    out
+}
+
+fn source_to_start_loc(source: &Source) -> Srcloc {
+    Srcloc::start(&source.kind.display(Path::new(".")))
+}
+
+fn syntax_item_loc(
+    sources: &HashMap<SourceKind, Source>,
+    source_kind: &SourceKind,
+    span: rowan::TextRange,
+) -> Option<Srcloc> {
+    let source = sources.get(source_kind)?;
+    let start = rue_diagnostic::LineCol::new(&source.text, span.start().into());
+    let end = rue_diagnostic::LineCol::new(&source.text, span.end().into());
+    let mut loc = Srcloc::new(
+        Rc::new(source.kind.display(Path::new("."))),
+        start.line + 1,
+        start.col + 1,
+    );
+    loc.until = Some(crate::compiler::srcloc::Until {
+        line: end.line + 1,
+        col: end.col + 1,
+    });
+    Some(loc)
+}
+
+fn build_symbol_locs(ctx: &Compiler, tree: &FileTree) -> HashMap<SymbolId, Srcloc> {
+    let sources: HashMap<SourceKind, Source> = tree
+        .all_files()
+        .into_iter()
+        .map(|file| (file.source.kind.clone(), file.source.clone()))
+        .collect();
+    let mut result = HashMap::new();
+
+    for item in ctx.syntax_map().items() {
+        if let SyntaxItemKind::SymbolDeclaration(symbol) = item.kind {
+            if let Some(loc) = syntax_item_loc(&sources, &item.source_kind, item.span) {
+                result.insert(symbol, loc);
+            }
+        }
+    }
+
+    result
+}
+
+fn parameter_expression(names: &[String]) -> String {
+    match names {
+        [] => "()".to_string(),
+        [name] => name.clone(),
+        _ => format!("({})", names.join(" ")),
+    }
+}
+
+fn add_function_symbol_metadata(
+    symbol_table: &mut HashMap<String, String>,
+    hash: String,
+    name: &str,
+    function: &FunctionSymbol,
+) {
+    symbol_table.insert(hash.clone(), name.to_string());
+    let arguments = function.parameters.keys().cloned().collect::<Vec<_>>();
+    let mut key = debug_decode_string(format!("{hash}_arguments").as_bytes());
+    symbol_table.insert(key, parameter_expression(&arguments));
+    key = debug_decode_string(format!("{hash}_left_env").as_bytes());
+    symbol_table.insert(key, "0".to_string());
+}
+
+fn compile_main(
+    ctx: &mut Compiler,
+    tree: &FileTree,
+    main: SymbolId,
+    base_path: PathBuf,
+    symbol_locs: &HashMap<SymbolId, Srcloc>,
+) -> Result<(RueSExp, HashMap<String, String>, HashMap<String, Srcloc>), String> {
+    let options = *ctx.options();
+    let graph = DependencyGraph::build(ctx, main, options);
+    let mut arena = Arena::new();
+    let mut lir_locs = HashMap::new();
+    let fallback_loc = tree
+        .all_files()
+        .first()
+        .map(|file| source_to_start_loc(&file.source))
+        .unwrap_or_else(|| Srcloc::start("*rue*"));
+    let lir = {
+        let mut lowerer = DebugLowerer::new(
+            ctx,
+            &mut arena,
+            &graph,
+            &mut lir_locs,
+            options,
+            main,
+            base_path,
+            symbol_locs,
+            fallback_loc,
+        );
+        lowerer.lower_symbol_value(&Environment::default(), main)
+    };
+
+    let compiled = codegen_debug(&arena, &lir_locs, lir);
+    let mut symbol_table = HashMap::new();
+    let mut program_locations = HashMap::new();
+
+    let relevant_declarations = ctx.relevant_declarations().collect::<Vec<_>>();
+    for item in relevant_declarations {
+        let rue_hir::Declaration::Symbol(symbol) = item else {
+            continue;
+        };
+        let Symbol::Function(function) = ctx.symbol(symbol).clone() else {
+            continue;
+        };
+        let Some(name) = function.name.as_ref().map(|name| name.text().to_string()) else {
+            continue;
+        };
+
+        if let Some(loc) = symbol_locs.get(&symbol).cloned() {
+            program_locations.insert(name.clone(), loc);
+        }
+
+        let mut body_arena = Arena::new();
+        let mut body_locs = HashMap::new();
+        let body_lir = {
+            let mut lowerer = DebugLowerer::new(
+                ctx,
+                &mut body_arena,
+                &graph,
+                &mut body_locs,
+                options,
+                main,
+                PathBuf::from("."),
+                symbol_locs,
+                symbol_locs
+                    .get(&symbol)
+                    .cloned()
+                    .unwrap_or_else(|| Srcloc::start("*rue*")),
+            );
+            lowerer.lower_symbol_value(&Environment::default(), symbol)
+        };
+        let function_sexp = codegen_debug(&body_arena, &body_locs, body_lir);
+        let function_hash = hex::encode(crate::compiler::debug::debug_sha256tree(function_sexp));
+        add_function_symbol_metadata(&mut symbol_table, function_hash, &name, &function);
+
+        // Non-main rue functions are represented as quoted CLVM bodies in the
+        // environment; map the dequoted body too so the JIT can name that block.
+        if let Some(body) = match &body_arena[body_lir] {
+            Lir::Quote(body) => Some(*body),
+            _ => None,
+        } {
+            let body_sexp = codegen_debug(&body_arena, &body_locs, body);
+            let body_hash = hex::encode(crate::compiler::debug::debug_sha256tree(body_sexp));
+            add_function_symbol_metadata(&mut symbol_table, body_hash, &name, &function);
+        }
+    }
+
+    Ok((compiled, symbol_table, program_locations))
+}
+
+pub fn compile_rue_to_arm_elf(args: &Args) -> Result<ArmElfCompileOutput, String> {
+    let mut allocator = Allocator::new();
+    let search_path = Path::new(&args.filename)
+        .canonicalize()
+        .map_err(|e| format!("failed to canonicalize {}: {e:?}", args.filename))?;
+    let project = find_project(&search_path, true)
+        .map_err(|e| format!("failed to find rue project: {e:?}"))?
+        .ok_or_else(|| format!("no rue project found for {}", args.filename))?;
+
+    let file_kind = Some(normalize_path(Path::new(&args.filename)).map_err(|e| format!("{e:?}"))?);
+    let main_kind = file_kind.clone().or_else(|| {
+        let main = project.entrypoint.join("main.rue");
+        if main.exists() {
+            normalize_path(&main).ok()
+        } else {
+            None
+        }
+    });
+
+    let mut ctx = Compiler::new(project.options);
+    let tree = FileTree::compile_path(&mut ctx, &project.entrypoint, &mut HashMap::new())
+        .map_err(|e| format!("failed to compile rue: {e:?}"))?;
+    let base_path = if project.entrypoint.is_file() {
+        project
+            .entrypoint
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .canonicalize()
+            .map_err(|e| format!("failed to canonicalize rue base path: {e:?}"))?
+    } else {
+        project
+            .entrypoint
+            .canonicalize()
+            .map_err(|e| format!("failed to canonicalize rue entrypoint: {e:?}"))?
+    };
+
+    let mut codegen_allowed = true;
+    for diagnostic in ctx.take_diagnostics() {
+        let message = diagnostic.message(&base_path);
+        if diagnostic.kind.severity() == DiagnosticSeverity::Error {
+            codegen_allowed = false;
+            eprintln!("Error: {message}");
+        } else {
+            eprintln!("Warning: {message}");
+        }
+    }
+    if !codegen_allowed {
+        return Err("rue compilation failed".to_string());
+    }
+
+    let main_kind = main_kind.ok_or_else(|| "no rue main function found".to_string())?;
+    let file = tree
+        .find(&main_kind)
+        .ok_or_else(|| format!("source not found in rue compilation unit: {main_kind:?}"))?;
+    let scope = ctx.module(file.module).scope;
+    let main = ctx
+        .scope(scope)
+        .symbol("main")
+        .ok_or_else(|| "no `main` function found in rue file".to_string())?;
+    let symbol_locs = build_symbol_locs(&ctx, &tree);
+    let (compiled, symbol_table, program_locations) =
+        compile_main(&mut ctx, &tree, main, base_path, &symbol_locs)?;
+
+    let env_node =
+        assemble(&mut allocator, &args.env).map_err(|e| format!("failed to read env: {e:?}"))?;
+    let env = convert_from_clvm_rs(&mut allocator, Srcloc::start("*env*"), env_node)
+        .map_err(|e| format!("failed to convert env program: {e:?}"))?;
+    let symbols = Rc::new(symbol_table.clone());
+
+    let program = Program::new(
+        program_locations,
+        &args.filename,
+        &args.output,
+        compiled,
+        RueSExp(env),
+        TARGET_ADDR,
+        symbols.clone(),
+    )?;
+
+    let ElfObject {
+        object_file,
+        synthetic_source,
+    } = program
+        .to_elf(&args.output)
+        .map_err(|e| format!("failed to create elf output: {e:?}"))?;
+
+    Ok(ArmElfCompileOutput {
+        object_file,
+        synthetic_source,
+        symbol_table,
+    })
+}

--- a/src/compiler/debug/armjit/rue.rs
+++ b/src/compiler/debug/armjit/rue.rs
@@ -1521,20 +1521,15 @@ fn compile_main(
             );
             lowerer.lower_symbol_value(&Environment::default(), symbol)
         };
-        let function_sexp = codegen_debug(&body_arena, &body_locs, body_lir);
+        let body_for_hash = match &body_arena[body_lir] {
+            // Non-main rue functions are carried through the environment as
+            // quoted bodies; the JIT executes the dequoted body.
+            Lir::Quote(body) => *body,
+            _ => body_lir,
+        };
+        let function_sexp = codegen_debug(&body_arena, &body_locs, body_for_hash);
         let function_hash = hex::encode(crate::compiler::debug::debug_sha256tree(function_sexp));
         add_function_symbol_metadata(&mut symbol_table, function_hash, &name, &function);
-
-        // Non-main rue functions are represented as quoted CLVM bodies in the
-        // environment; map the dequoted body too so the JIT can name that block.
-        if let Some(body) = match &body_arena[body_lir] {
-            Lir::Quote(body) => Some(*body),
-            _ => None,
-        } {
-            let body_sexp = codegen_debug(&body_arena, &body_locs, body);
-            let body_hash = hex::encode(crate::compiler::debug::debug_sha256tree(body_sexp));
-            add_function_symbol_metadata(&mut symbol_table, body_hash, &name, &function);
-        }
     }
 
     Ok((compiled, symbol_table, program_locations))

--- a/src/compiler/debug/armjit/rue.rs
+++ b/src/compiler/debug/armjit/rue.rs
@@ -113,6 +113,7 @@ struct DebugLowerer<'d, 'a, 'g> {
     graph: &'g DependencyGraph,
     lir_locs: &'a mut HashMap<LirId, Srcloc>,
     function_body_lirs: &'a mut HashMap<SymbolId, LirId>,
+    function_argument_trees: &'a mut HashMap<SymbolId, String>,
     inline_symbols: Vec<HashMap<SymbolId, HirId>>,
     options: rue_options::CompilerOptions,
     main: SymbolId,
@@ -128,6 +129,7 @@ impl<'d, 'a, 'g> DebugLowerer<'d, 'a, 'g> {
         graph: &'g DependencyGraph,
         lir_locs: &'a mut HashMap<LirId, Srcloc>,
         function_body_lirs: &'a mut HashMap<SymbolId, LirId>,
+        function_argument_trees: &'a mut HashMap<SymbolId, String>,
         options: rue_options::CompilerOptions,
         main: SymbolId,
         base_path: PathBuf,
@@ -140,6 +142,7 @@ impl<'d, 'a, 'g> DebugLowerer<'d, 'a, 'g> {
             graph,
             lir_locs,
             function_body_lirs,
+            function_argument_trees,
             inline_symbols: Vec::new(),
             options,
             main,
@@ -234,6 +237,10 @@ impl<'d, 'a, 'g> DebugLowerer<'d, 'a, 'g> {
         for group in &capture_groups {
             function_env = Self::apply_group(function_env, group, true);
         }
+        self.function_argument_trees.insert(
+            symbol,
+            argument_tree_expression(&function_env, &function.parameters),
+        );
 
         let mut expr = self.lower_hir(&function_env, function.body);
 
@@ -1445,16 +1452,38 @@ fn parameter_expression(names: &[String]) -> String {
     }
 }
 
+fn argument_tree_expression(env: &Environment, parameters: &IndexMap<String, SymbolId>) -> String {
+    match env {
+        Environment::Nil => "()".to_string(),
+        Environment::Leaf(symbol) => parameters
+            .iter()
+            .find_map(|(name, parameter)| {
+                if parameter == symbol {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| "()".to_string()),
+        Environment::Pair(first, rest) => {
+            format!(
+                "({} . {})",
+                argument_tree_expression(first, parameters),
+                argument_tree_expression(rest, parameters)
+            )
+        }
+    }
+}
+
 fn add_function_symbol_metadata(
     symbol_table: &mut HashMap<String, String>,
     hash: String,
     name: &str,
-    function: &FunctionSymbol,
+    arguments: &str,
 ) {
     symbol_table.insert(hash.clone(), name.to_string());
-    let arguments = function.parameters.keys().cloned().collect::<Vec<_>>();
     let mut key = debug_decode_string(format!("{hash}_arguments").as_bytes());
-    symbol_table.insert(key, parameter_expression(&arguments));
+    symbol_table.insert(key, arguments.to_string());
     key = debug_decode_string(format!("{hash}_left_env").as_bytes());
     symbol_table.insert(key, "0".to_string());
 }
@@ -1471,6 +1500,7 @@ fn compile_main(
     let mut arena = Arena::new();
     let mut lir_locs = HashMap::new();
     let mut function_body_lirs = HashMap::new();
+    let mut function_argument_trees = HashMap::new();
     let fallback_loc = tree
         .all_files()
         .first()
@@ -1483,6 +1513,7 @@ fn compile_main(
             &graph,
             &mut lir_locs,
             &mut function_body_lirs,
+            &mut function_argument_trees,
             options,
             main,
             base_path,
@@ -1515,9 +1546,15 @@ fn compile_main(
         let Some(body_lir) = function_body_lirs.get(&symbol).copied() else {
             continue;
         };
+        let arguments = function_argument_trees
+            .get(&symbol)
+            .cloned()
+            .unwrap_or_else(|| {
+                parameter_expression(&function.parameters.keys().cloned().collect::<Vec<_>>())
+            });
         let function_sexp = codegen_debug(&arena, &lir_locs, body_lir);
         let function_hash = hex::encode(crate::compiler::debug::debug_sha256tree(function_sexp));
-        add_function_symbol_metadata(&mut symbol_table, function_hash, &name, &function);
+        add_function_symbol_metadata(&mut symbol_table, function_hash, &name, &arguments);
     }
 
     Ok((compiled, symbol_table, program_locations))

--- a/src/compiler/debug/armjit/rue.rs
+++ b/src/compiler/debug/armjit/rue.rs
@@ -112,6 +112,7 @@ struct DebugLowerer<'d, 'a, 'g> {
     arena: &'a mut Arena<Lir>,
     graph: &'g DependencyGraph,
     lir_locs: &'a mut HashMap<LirId, Srcloc>,
+    function_body_lirs: &'a mut HashMap<SymbolId, LirId>,
     inline_symbols: Vec<HashMap<SymbolId, HirId>>,
     options: rue_options::CompilerOptions,
     main: SymbolId,
@@ -126,6 +127,7 @@ impl<'d, 'a, 'g> DebugLowerer<'d, 'a, 'g> {
         arena: &'a mut Arena<Lir>,
         graph: &'g DependencyGraph,
         lir_locs: &'a mut HashMap<LirId, Srcloc>,
+        function_body_lirs: &'a mut HashMap<SymbolId, LirId>,
         options: rue_options::CompilerOptions,
         main: SymbolId,
         base_path: PathBuf,
@@ -137,6 +139,7 @@ impl<'d, 'a, 'g> DebugLowerer<'d, 'a, 'g> {
             arena,
             graph,
             lir_locs,
+            function_body_lirs,
             inline_symbols: Vec::new(),
             options,
             main,
@@ -271,8 +274,10 @@ impl<'d, 'a, 'g> DebugLowerer<'d, 'a, 'g> {
                 expr = self.alloc_here(Lir::Run(expr, group_env));
             }
 
+            self.function_body_lirs.insert(symbol, expr);
             expr
         } else {
+            self.function_body_lirs.insert(symbol, expr);
             self.alloc_here(Lir::Quote(expr))
         }
     }
@@ -1465,6 +1470,7 @@ fn compile_main(
     let graph = DependencyGraph::build(ctx, main, options);
     let mut arena = Arena::new();
     let mut lir_locs = HashMap::new();
+    let mut function_body_lirs = HashMap::new();
     let fallback_loc = tree
         .all_files()
         .first()
@@ -1476,6 +1482,7 @@ fn compile_main(
             &mut arena,
             &graph,
             &mut lir_locs,
+            &mut function_body_lirs,
             options,
             main,
             base_path,
@@ -1505,32 +1512,10 @@ fn compile_main(
             program_locations.insert(name.clone(), loc);
         }
 
-        let mut body_arena = Arena::new();
-        let mut body_locs = HashMap::new();
-        let body_lir = {
-            let mut lowerer = DebugLowerer::new(
-                ctx,
-                &mut body_arena,
-                &graph,
-                &mut body_locs,
-                options,
-                main,
-                PathBuf::from("."),
-                symbol_locs,
-                symbol_locs
-                    .get(&symbol)
-                    .cloned()
-                    .unwrap_or_else(|| Srcloc::start("*rue*")),
-            );
-            lowerer.lower_symbol_value(&Environment::default(), symbol)
+        let Some(body_lir) = function_body_lirs.get(&symbol).copied() else {
+            continue;
         };
-        let body_for_hash = match &body_arena[body_lir] {
-            // Non-main rue functions are carried through the environment as
-            // quoted bodies; the JIT executes the dequoted body.
-            Lir::Quote(body) => *body,
-            _ => body_lir,
-        };
-        let function_sexp = codegen_debug(&body_arena, &body_locs, body_for_hash);
+        let function_sexp = codegen_debug(&arena, &lir_locs, body_lir);
         let function_hash = hex::encode(crate::compiler::debug::debug_sha256tree(function_sexp));
         add_function_symbol_metadata(&mut symbol_table, function_hash, &name, &function);
     }

--- a/src/compiler/debug/armjit/rue.rs
+++ b/src/compiler/debug/armjit/rue.rs
@@ -1430,6 +1430,9 @@ fn build_symbol_locs(ctx: &Compiler, tree: &FileTree) -> HashMap<SymbolId, Srclo
 }
 
 fn parameter_expression(names: &[String]) -> String {
+    if std::env::var_os("ARMTX_RUE_FORCE_ENV_ARGS").is_some() {
+        return "ENV".to_string();
+    }
     match names {
         [] => "()".to_string(),
         [name] => name.clone(),

--- a/src/compiler/debug/armjit/rue.rs
+++ b/src/compiler/debug/armjit/rue.rs
@@ -1501,6 +1501,10 @@ fn compile_main(
             continue;
         };
 
+        if let Some(loc) = symbol_locs.get(&symbol).cloned() {
+            program_locations.insert(name.clone(), loc);
+        }
+
         let mut body_arena = Arena::new();
         let mut body_locs = HashMap::new();
         let body_lir = {

--- a/support/gdb_print_sexp.py
+++ b/support/gdb_print_sexp.py
@@ -89,29 +89,3 @@ def lookup_type(val):
     return None
 
 gdb.pretty_printers.append(lookup_type)
-
-def clvm_path(value, path):
-    path = int(path)
-    ops = []
-    while path > 1:
-        ops.append(path & 1)
-        path >>= 1
-    for op in reversed(ops):
-        if not value.is_cons():
-            raise gdb.GdbError("CLVM path reached atom before target")
-        value = value.cons[1 if op else 0]
-    return value
-
-class PrintClvmPath(gdb.Command):
-    def __init__(self):
-        super(PrintClvmPath, self).__init__("print_clvm_path", gdb.COMMAND_DATA)
-
-    def invoke(self, arg, from_tty):
-        argv = gdb.string_to_argv(arg)
-        if len(argv) != 2:
-            raise gdb.GdbError("usage: print_clvm_path ADDRESS PATH")
-        address = int(gdb.parse_and_eval(argv[0]))
-        path = int(argv[1], 0)
-        print(clvm_path(value(address), path).to_string())
-
-PrintClvmPath()

--- a/support/gdb_print_sexp.py
+++ b/support/gdb_print_sexp.py
@@ -89,3 +89,29 @@ def lookup_type(val):
     return None
 
 gdb.pretty_printers.append(lookup_type)
+
+def clvm_path(value, path):
+    path = int(path)
+    ops = []
+    while path > 1:
+        ops.append(path & 1)
+        path >>= 1
+    for op in reversed(ops):
+        if not value.is_cons():
+            raise gdb.GdbError("CLVM path reached atom before target")
+        value = value.cons[1 if op else 0]
+    return value
+
+class PrintClvmPath(gdb.Command):
+    def __init__(self):
+        super(PrintClvmPath, self).__init__("print_clvm_path", gdb.COMMAND_DATA)
+
+    def invoke(self, arg, from_tty):
+        argv = gdb.string_to_argv(arg)
+        if len(argv) != 2:
+            raise gdb.GdbError("usage: print_clvm_path ADDRESS PATH")
+        address = int(gdb.parse_and_eval(argv[0]))
+        path = int(argv[1], 0)
+        print(clvm_path(value(address), path).to_string())
+
+PrintClvmPath()

--- a/vendor/rue-ast/Cargo.toml
+++ b/vendor/rue-ast/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rue-ast"
+version = "0.8.4"
+edition = "2024"
+license = "Apache-2.0"
+description = "An implementation of the Abstract Syntax Tree for the Rue compiler."
+authors = ["Brandon Haggstrom <me@rigidnetwork.com>"]
+homepage = "https://github.com/xch-dev/rue"
+repository = "https://github.com/xch-dev/rue"
+readme = "README.md"
+keywords = ["chia", "blockchain", "crypto"]
+categories = ["cryptography::cryptocurrencies", "development-tools"]
+
+[dependencies]
+rue-parser = { git = "https://github.com/xch-dev/rue.git", version = "0.8.4" }

--- a/vendor/rue-ast/src/lib.rs
+++ b/vendor/rue-ast/src/lib.rs
@@ -1,0 +1,905 @@
+use rue_parser::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, T};
+
+pub trait AstNode {
+    fn cast(node: SyntaxNode) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn syntax(&self) -> &SyntaxNode;
+}
+
+macro_rules! ast_node_impl {
+    ($name:ident, $kind:ident) => {
+        #[derive(Debug, Clone)]
+        pub struct $name(SyntaxNode);
+
+        impl AstNode for $name {
+            fn cast(node: SyntaxNode) -> Option<Self> {
+                match node.kind() {
+                    SyntaxKind::$kind => Some(Self(node)),
+                    _ => None,
+                }
+            }
+
+            fn syntax(&self) -> &SyntaxNode {
+                &self.0
+            }
+        }
+    };
+}
+
+macro_rules! ast_enum_impl {
+    ($name:ident, $( $variant:ident($node:ident) ),+ $(,)? ) => {
+        #[derive(Debug, Clone)]
+        pub enum $name {
+            $( $variant($node), )+
+        }
+
+        impl AstNode for $name {
+            fn cast(node: SyntaxNode) -> Option<Self> {
+                $( if let Some(node) = $node::cast(node.clone()) {
+                    return Some(Self::$variant(node));
+                } )+
+                None
+            }
+
+            fn syntax(&self) -> &SyntaxNode {
+                match self {
+                    $( Self::$variant(node) => node.syntax(), )+
+                }
+            }
+        }
+    };
+}
+
+ast_node_impl!(AstDocument, Document);
+ast_node_impl!(AstModuleItem, ModuleItem);
+ast_node_impl!(AstFunctionItem, FunctionItem);
+ast_node_impl!(AstFunctionParameter, FunctionParameter);
+ast_node_impl!(AstConstantItem, ConstantItem);
+ast_node_impl!(AstTypeAliasItem, TypeAliasItem);
+ast_node_impl!(AstStructItem, StructItem);
+ast_node_impl!(AstStructField, StructField);
+ast_node_impl!(AstImportItem, ImportItem);
+ast_node_impl!(AstImportPath, ImportPath);
+ast_node_impl!(AstImportPathSegment, ImportPathSegment);
+ast_node_impl!(AstGenericParameters, GenericParameters);
+ast_node_impl!(AstGenericArguments, GenericArguments);
+ast_node_impl!(AstLiteralType, LiteralType);
+ast_node_impl!(AstPathType, PathType);
+ast_node_impl!(AstUnionType, UnionType);
+ast_node_impl!(AstGroupType, GroupType);
+ast_node_impl!(AstPairType, PairType);
+ast_node_impl!(AstListType, ListType);
+ast_node_impl!(AstListTypeItem, ListTypeItem);
+ast_node_impl!(AstLambdaType, LambdaType);
+ast_node_impl!(AstLambdaParameter, LambdaParameter);
+ast_node_impl!(AstBlock, Block);
+ast_node_impl!(AstLetStmt, LetStmt);
+ast_node_impl!(AstExprStmt, ExprStmt);
+ast_node_impl!(AstIfStmt, IfStmt);
+ast_node_impl!(AstReturnStmt, ReturnStmt);
+ast_node_impl!(AstAssertStmt, AssertStmt);
+ast_node_impl!(AstRaiseStmt, RaiseStmt);
+ast_node_impl!(AstDebugStmt, DebugStmt);
+ast_node_impl!(AstPathExpr, PathExpr);
+ast_node_impl!(AstPathSegment, PathSegment);
+ast_node_impl!(AstStructInitializerExpr, StructInitializerExpr);
+ast_node_impl!(AstStructInitializerField, StructInitializerField);
+ast_node_impl!(AstLiteralExpr, LiteralExpr);
+ast_node_impl!(AstGroupExpr, GroupExpr);
+ast_node_impl!(AstPairExpr, PairExpr);
+ast_node_impl!(AstListExpr, ListExpr);
+ast_node_impl!(AstListItem, ListItem);
+ast_node_impl!(AstPrefixExpr, PrefixExpr);
+ast_node_impl!(AstBinaryExpr, BinaryExpr);
+ast_node_impl!(AstFunctionCallExpr, FunctionCallExpr);
+ast_node_impl!(AstIfExpr, IfExpr);
+ast_node_impl!(AstGuardExpr, GuardExpr);
+ast_node_impl!(AstCastExpr, CastExpr);
+ast_node_impl!(AstFieldAccessExpr, FieldAccessExpr);
+ast_node_impl!(AstLambdaExpr, LambdaExpr);
+ast_node_impl!(AstNamedBinding, NamedBinding);
+ast_node_impl!(AstPairBinding, PairBinding);
+ast_node_impl!(AstListBinding, ListBinding);
+ast_node_impl!(AstListBindingItem, ListBindingItem);
+ast_node_impl!(AstStructBinding, StructBinding);
+ast_node_impl!(AstStructFieldBinding, StructFieldBinding);
+
+ast_enum_impl!(
+    AstItem,
+    TypeItem(AstTypeItem),
+    SymbolItem(AstSymbolItem),
+    ImportItem(AstImportItem),
+);
+ast_enum_impl!(
+    AstTypeItem,
+    TypeAliasItem(AstTypeAliasItem),
+    StructItem(AstStructItem),
+);
+ast_enum_impl!(
+    AstSymbolItem,
+    ModuleItem(AstModuleItem),
+    FunctionItem(AstFunctionItem),
+    ConstantItem(AstConstantItem),
+);
+ast_enum_impl!(
+    AstStmt,
+    LetStmt(AstLetStmt),
+    ExprStmt(AstExprStmt),
+    IfStmt(AstIfStmt),
+    ReturnStmt(AstReturnStmt),
+    AssertStmt(AstAssertStmt),
+    RaiseStmt(AstRaiseStmt),
+    DebugStmt(AstDebugStmt),
+);
+ast_enum_impl!(AstStmtOrExpr, Stmt(AstStmt), Expr(AstExpr));
+ast_enum_impl!(
+    AstExpr,
+    PathExpr(AstPathExpr),
+    StructInitializerExpr(AstStructInitializerExpr),
+    LiteralExpr(AstLiteralExpr),
+    GroupExpr(AstGroupExpr),
+    PairExpr(AstPairExpr),
+    ListExpr(AstListExpr),
+    PrefixExpr(AstPrefixExpr),
+    BinaryExpr(AstBinaryExpr),
+    FunctionCallExpr(AstFunctionCallExpr),
+    Block(AstBlock),
+    IfExpr(AstIfExpr),
+    GuardExpr(AstGuardExpr),
+    CastExpr(AstCastExpr),
+    FieldAccessExpr(AstFieldAccessExpr),
+    LambdaExpr(AstLambdaExpr),
+);
+ast_enum_impl!(
+    AstType,
+    LiteralType(AstLiteralType),
+    PathType(AstPathType),
+    UnionType(AstUnionType),
+    GroupType(AstGroupType),
+    PairType(AstPairType),
+    ListType(AstListType),
+    LambdaType(AstLambdaType),
+);
+ast_enum_impl!(
+    AstBinding,
+    NamedBinding(AstNamedBinding),
+    PairBinding(AstPairBinding),
+    ListBinding(AstListBinding),
+    StructBinding(AstStructBinding),
+);
+
+impl AstDocument {
+    pub fn items(&self) -> impl Iterator<Item = AstItem> {
+        self.syntax().children().filter_map(AstItem::cast)
+    }
+}
+
+impl AstModuleItem {
+    pub fn export(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![export])
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+
+    pub fn items(&self) -> impl Iterator<Item = AstItem> {
+        self.syntax().children().filter_map(AstItem::cast)
+    }
+}
+
+impl AstFunctionItem {
+    pub fn export(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![export])
+    }
+
+    pub fn extern_kw(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![extern])
+    }
+
+    pub fn inline(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![inline])
+    }
+
+    pub fn test(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![test])
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+
+    pub fn generic_parameters(&self) -> Option<AstGenericParameters> {
+        self.syntax()
+            .children()
+            .find_map(AstGenericParameters::cast)
+    }
+
+    pub fn parameters(&self) -> impl Iterator<Item = AstFunctionParameter> {
+        self.syntax()
+            .children()
+            .filter_map(AstFunctionParameter::cast)
+    }
+
+    pub fn return_type(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+
+    pub fn body(&self) -> Option<AstBlock> {
+        self.syntax().children().find_map(AstBlock::cast)
+    }
+}
+
+impl AstConstantItem {
+    pub fn export(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![export])
+    }
+
+    pub fn inline(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![inline])
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+
+    pub fn value(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstTypeAliasItem {
+    pub fn export(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![export])
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+
+    pub fn generic_parameters(&self) -> Option<AstGenericParameters> {
+        self.syntax()
+            .children()
+            .find_map(AstGenericParameters::cast)
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+}
+
+impl AstStructItem {
+    pub fn export(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![export])
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+
+    pub fn generic_parameters(&self) -> Option<AstGenericParameters> {
+        self.syntax()
+            .children()
+            .find_map(AstGenericParameters::cast)
+    }
+
+    pub fn fields(&self) -> impl Iterator<Item = AstStructField> {
+        self.syntax().children().filter_map(AstStructField::cast)
+    }
+}
+
+impl AstStructField {
+    pub fn spread(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![...])
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstImportItem {
+    pub fn export(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![export])
+    }
+
+    pub fn path(&self) -> Option<AstImportPath> {
+        self.syntax().children().find_map(AstImportPath::cast)
+    }
+}
+
+impl AstImportPath {
+    pub fn segments(&self) -> impl Iterator<Item = AstImportPathSegment> {
+        self.syntax()
+            .children()
+            .filter_map(AstImportPathSegment::cast)
+    }
+}
+
+impl AstImportPathSegment {
+    pub fn separator(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![::])
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident || token.kind() == T![super])
+    }
+
+    pub fn star(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![*])
+    }
+
+    pub fn items(&self) -> impl Iterator<Item = AstImportPath> {
+        self.syntax().children().filter_map(AstImportPath::cast)
+    }
+}
+
+impl AstFunctionParameter {
+    pub fn spread(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![...])
+    }
+
+    pub fn binding(&self) -> Option<AstBinding> {
+        self.syntax().children().find_map(AstBinding::cast)
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+}
+
+impl AstGenericParameters {
+    pub fn names(&self) -> impl Iterator<Item = SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .filter(|token| token.kind() == SyntaxKind::Ident)
+    }
+}
+
+impl AstGenericArguments {
+    pub fn types(&self) -> impl Iterator<Item = AstType> {
+        self.syntax().children().filter_map(AstType::cast)
+    }
+}
+
+impl AstBlock {
+    pub fn items(&self) -> impl Iterator<Item = AstStmtOrExpr> {
+        self.syntax().children().filter_map(AstStmtOrExpr::cast)
+    }
+}
+
+impl AstLetStmt {
+    pub fn inline(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![inline])
+    }
+
+    pub fn binding(&self) -> Option<AstBinding> {
+        self.syntax().children().find_map(AstBinding::cast)
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+
+    pub fn value(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstExprStmt {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstIfStmt {
+    pub fn inline(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![inline])
+    }
+
+    pub fn condition(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+
+    pub fn then_block(&self) -> Option<AstBlock> {
+        self.syntax()
+            .children()
+            .filter(|node| AstExpr::cast(node.clone()).is_some())
+            .nth(1)
+            .and_then(AstBlock::cast)
+    }
+}
+
+impl AstReturnStmt {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstAssertStmt {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstRaiseStmt {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstDebugStmt {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstPathExpr {
+    pub fn segments(&self) -> impl Iterator<Item = AstPathSegment> {
+        self.syntax().children().filter_map(AstPathSegment::cast)
+    }
+}
+
+impl AstPathSegment {
+    pub fn separator(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![::])
+            .filter(|token| {
+                let Some(name) = self.name() else {
+                    return true;
+                };
+                token.text_range().start() < name.text_range().start()
+            })
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident || token.kind() == T![super])
+    }
+
+    pub fn generic_arguments(&self) -> Option<AstGenericArguments> {
+        self.syntax().children().find_map(AstGenericArguments::cast)
+    }
+}
+
+impl AstStructInitializerExpr {
+    pub fn path(&self) -> Option<AstPathExpr> {
+        self.syntax().children().find_map(AstPathExpr::cast)
+    }
+
+    pub fn fields(&self) -> impl Iterator<Item = AstStructInitializerField> {
+        self.syntax()
+            .children()
+            .filter_map(AstStructInitializerField::cast)
+    }
+}
+
+impl AstStructInitializerField {
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstLiteralExpr {
+    pub fn value(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| SyntaxKind::LITERAL.contains(&token.kind()))
+    }
+}
+
+impl AstGroupExpr {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstPairExpr {
+    pub fn first(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+
+    pub fn rest(&self) -> Option<AstExpr> {
+        self.syntax().children().filter_map(AstExpr::cast).nth(1)
+    }
+}
+
+impl AstListExpr {
+    pub fn items(&self) -> impl Iterator<Item = AstListItem> {
+        self.syntax().children().filter_map(AstListItem::cast)
+    }
+}
+
+impl AstListItem {
+    pub fn spread(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![...])
+    }
+
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstPrefixExpr {
+    pub fn op(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| SyntaxKind::PREFIX_OPS.contains(&token.kind()))
+    }
+
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstBinaryExpr {
+    pub fn op(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| SyntaxKind::BINARY_OPS.contains(&token.kind()))
+    }
+
+    pub fn left(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+
+    pub fn right(&self) -> Option<AstExpr> {
+        self.syntax().children().filter_map(AstExpr::cast).nth(1)
+    }
+}
+
+impl AstFunctionCallExpr {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+
+    pub fn args(&self) -> impl Iterator<Item = AstListItem> {
+        self.syntax().children().filter_map(AstListItem::cast)
+    }
+}
+
+impl AstIfExpr {
+    pub fn inline(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![inline])
+    }
+
+    pub fn condition(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+
+    pub fn then_expr(&self) -> Option<AstExpr> {
+        self.syntax().children().filter_map(AstExpr::cast).nth(1)
+    }
+
+    pub fn else_expr(&self) -> Option<AstExpr> {
+        self.syntax().children().filter_map(AstExpr::cast).nth(2)
+    }
+}
+
+impl AstGuardExpr {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+}
+
+impl AstCastExpr {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+}
+
+impl AstFieldAccessExpr {
+    pub fn expr(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+
+    pub fn dot(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![.])
+    }
+
+    pub fn field(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+}
+
+impl AstLambdaExpr {
+    pub fn generic_parameters(&self) -> Option<AstGenericParameters> {
+        self.syntax()
+            .children()
+            .find_map(AstGenericParameters::cast)
+    }
+
+    pub fn parameters(&self) -> impl Iterator<Item = AstFunctionParameter> {
+        self.syntax()
+            .children()
+            .filter_map(AstFunctionParameter::cast)
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+
+    pub fn body(&self) -> Option<AstExpr> {
+        self.syntax().children().find_map(AstExpr::cast)
+    }
+}
+
+impl AstLiteralType {
+    pub fn value(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| SyntaxKind::LITERAL.contains(&token.kind()))
+    }
+}
+
+impl AstPathType {
+    pub fn segments(&self) -> impl Iterator<Item = AstPathSegment> {
+        self.syntax().children().filter_map(AstPathSegment::cast)
+    }
+}
+
+impl AstUnionType {
+    pub fn types(&self) -> impl Iterator<Item = AstType> {
+        self.syntax().children().filter_map(AstType::cast)
+    }
+}
+
+impl AstGroupType {
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+}
+
+impl AstPairType {
+    pub fn first(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+
+    pub fn rest(&self) -> Option<AstType> {
+        self.syntax().children().filter_map(AstType::cast).nth(1)
+    }
+}
+
+impl AstListType {
+    pub fn items(&self) -> impl Iterator<Item = AstListTypeItem> {
+        self.syntax().children().filter_map(AstListTypeItem::cast)
+    }
+}
+
+impl AstListTypeItem {
+    pub fn spread(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![...])
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+}
+
+impl AstLambdaType {
+    pub fn generic_parameters(&self) -> Option<AstGenericParameters> {
+        self.syntax()
+            .children()
+            .find_map(AstGenericParameters::cast)
+    }
+
+    pub fn parameters(&self) -> impl Iterator<Item = AstLambdaParameter> {
+        self.syntax()
+            .children()
+            .filter_map(AstLambdaParameter::cast)
+    }
+
+    pub fn return_type(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+}
+
+impl AstLambdaParameter {
+    pub fn spread(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![...])
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+
+    pub fn ty(&self) -> Option<AstType> {
+        self.syntax().children().find_map(AstType::cast)
+    }
+}
+
+impl AstNamedBinding {
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+}
+
+impl AstPairBinding {
+    pub fn first(&self) -> Option<AstBinding> {
+        self.syntax().children().find_map(AstBinding::cast)
+    }
+
+    pub fn rest(&self) -> Option<AstBinding> {
+        self.syntax().children().filter_map(AstBinding::cast).nth(1)
+    }
+}
+
+impl AstListBinding {
+    pub fn items(&self) -> impl Iterator<Item = AstListBindingItem> {
+        self.syntax()
+            .children()
+            .filter_map(AstListBindingItem::cast)
+    }
+}
+
+impl AstListBindingItem {
+    pub fn spread(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![...])
+    }
+
+    pub fn binding(&self) -> Option<AstBinding> {
+        self.syntax().children().find_map(AstBinding::cast)
+    }
+}
+
+impl AstStructBinding {
+    pub fn fields(&self) -> impl Iterator<Item = AstStructFieldBinding> {
+        self.syntax()
+            .children()
+            .filter_map(AstStructFieldBinding::cast)
+    }
+}
+
+impl AstStructFieldBinding {
+    pub fn spread(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == T![...])
+    }
+
+    pub fn name(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .find(|token| token.kind() == SyntaxKind::Ident)
+    }
+
+    pub fn binding(&self) -> Option<AstBinding> {
+        self.syntax().children().find_map(AstBinding::cast)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a rue debug ARM JIT compilation path with source-location-aware lowering/codegen into DebugSExp
- dispatch armtx to rue compilation for .rue files while preserving existing chialisp behavior
- add rue factorial debug/run scripts
- avoid duplicate rue debug aliases and duplicate emitted debug aliases
- fix quoted apply branches to use generated code labels
- normalize rue source paths in debug info and set the gdb architecture in the rue gdb script
- stop declaring/emitting empty alias sections for colloquial debug names
- emit a single DWARF subprogram DIE for source-named debug functions
- map rue executable function labels back to source function names
- patch rue-ast locally to remove the Socket-blocked paste proc-macro dependency
- record rue executable function body hashes during the real lowering pass instead of re-lowering functions in an empty environment
- capture rue argument names/paths during the same lowering pass and emit them into the chialisp-compatible hash `_arguments` symbol metadata
- emit the ARM JIT ELF as an `ET_EXEC` image with a `PT_LOAD` segment covering the bare-metal load span

## Verification
- cargo fmt --check
- cargo check --bin armtx
- cargo clippy --workspace -- -D warnings
- cargo build --bin armtx
- resources/tests/test_rue_sdc.sh + resources/tests/test_rue_sdc_gdb.sh (GDB resolves `factorial(num=...)` for values 6 through 1 and produces `CLVM: 720`)
- generated `rue_sdc.elf` is `ELF 32-bit LSB executable, ARM` with entry point `0x1000` and one `PT_LOAD`
- cargo tree -i paste --edges normal,build,dev reports no `paste` package

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d762b4b-591a-4856-b794-d52526aed6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d762b4b-591a-4856-b794-d52526aed6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

