### PR TITLE
Preserve module constant tabled flags

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -517,7 +517,14 @@ pub fn get_callable(
                 }
                 (_, _, Ok(defun), _, _, _) => {
                     let defun_clone: &SExp = defun.borrow();
-                    Ok(Callable::CallDefun(l.clone(), defun_clone.clone()))
+                    Ok(Callable::CallDefun(
+                        l.clone(),
+                        defun_clone.clone(),
+                        matches!(
+                            is_defun_or_constant_in_codegen(compiler, name),
+                            Some(EnvDefinitionStatus::IsDefun)
+                        ),
+                    ))
                 }
                 (_, _, _, Some(prim), _, _) => {
                     let prim_clone: &SExp = prim.borrow();
@@ -794,7 +801,7 @@ fn compile_call(
                 call.tail.clone(),
             ),
 
-            Callable::CallDefun(l, lookup) => generate_args_code(
+            Callable::CallDefun(l, lookup, expects_left_env) => generate_args_code(
                 context,
                 opts.clone(),
                 compiler,
@@ -809,9 +816,16 @@ fn compile_call(
                 },
                 true,
             )
-            .and_then(|args| {
-                process_defun_call(opts.clone(), compiler, l.clone(), args, Rc::new(lookup))
-            }),
+            .map(|args| {
+                if expects_left_env {
+                    process_defun_call(opts.clone(), compiler, l.clone(), args, Rc::new(lookup))
+                } else {
+                    Ok(CompiledCode(
+                        l.clone(),
+                        Rc::new(primapply(l, Rc::new(lookup), args)),
+                    ))
+                }
+            })?,
 
             Callable::CallPrim(l, p) => generate_args_code(
                 context,
@@ -1038,6 +1052,11 @@ pub fn generate_expr_code(
                         )
                         .map(|f| Ok(CompiledCode(l.clone(), f)))
                         .unwrap_or_else(|_| {
+                            if let Some(res) = compiler.tabled_constants.get(atom) {
+                                let quoted = primquote(l.clone(), res.clone());
+                                return Ok(CompiledCode(l.clone(), Rc::new(quoted)));
+                            }
+
                             if opts.dialect().strict && printable(atom, false) {
                                 // Finally enable strictness for variable names.
                                 // This is possible because the modern macro system

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -217,11 +217,9 @@ pub fn find_exported_helper(
 fn modernize_constants(helpers: &mut [HelperForm], standalone_constants: &HashSet<Vec<u8>>) {
     for h in helpers.iter_mut() {
         match h {
-            HelperForm::Defconstant(d) => {
+            HelperForm::Defconstant(d) if standalone_constants.contains(&d.name) => {
                 // Ensure that we upgrade the constant type.
-                if standalone_constants.contains(&d.name) {
-                    d.kind = ConstantKind::Module;
-                }
+                d.kind = ConstantKind::Module;
             }
             HelperForm::Defnamespace(ns) => {
                 modernize_constants(&mut ns.helpers, standalone_constants);
@@ -234,10 +232,8 @@ fn modernize_constants(helpers: &mut [HelperForm], standalone_constants: &HashSe
 fn force_constants_inline(helpers: &mut [HelperForm], inline_constants: &HashSet<Vec<u8>>) {
     for h in helpers.iter_mut() {
         match h {
-            HelperForm::Defconstant(d) => {
-                if inline_constants.contains(&d.name) {
-                    d.tabled = false;
-                }
+            HelperForm::Defconstant(d) if inline_constants.contains(&d.name) => {
+                d.tabled = false;
             }
             HelperForm::Defnamespace(ns) => {
                 force_constants_inline(&mut ns.helpers, inline_constants);

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -219,7 +219,6 @@ fn modernize_constants(helpers: &mut [HelperForm], standalone_constants: &HashSe
         match h {
             HelperForm::Defconstant(d) => {
                 // Ensure that we upgrade the constant type.
-                d.tabled = false;
                 if standalone_constants.contains(&d.name) {
                     d.kind = ConstantKind::Module;
                 }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -231,6 +231,27 @@ fn modernize_constants(helpers: &mut [HelperForm], standalone_constants: &HashSe
     }
 }
 
+fn force_constants_inline(helpers: &mut [HelperForm], inline_constants: &HashSet<Vec<u8>>) {
+    for h in helpers.iter_mut() {
+        match h {
+            HelperForm::Defconstant(d) => {
+                if inline_constants.contains(&d.name) {
+                    d.tabled = false;
+                }
+            }
+            HelperForm::Defnamespace(ns) => {
+                force_constants_inline(&mut ns.helpers, inline_constants);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn force_constant_inline(helpers: &mut [HelperForm], name: &[u8]) {
+    let inline_constants = HashSet::from([name.to_vec()]);
+    force_constants_inline(helpers, &inline_constants);
+}
+
 fn capture_standalone_constants(
     standalone_constants: &mut HashSet<Vec<u8>>,
     depgraph: &FunctionDependencyGraph,
@@ -601,7 +622,7 @@ pub fn compile_module(
             &mut constant_culled_second_stage_program.helpers,
             standalone_constants,
         );
-
+        force_constant_inline(&mut constant_culled_second_stage_program.helpers, &fun_name);
         let compiled_result = Rc::new(compile_from_compileform(
             context,
             second_stage_opts.clone(),

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -63,8 +63,9 @@ impl InlineFunction {
 pub enum Callable {
     /// The expression is a macro expansion (list, if etc.)
     CallMacro(Srcloc, SExp),
-    /// The expression invokes an env defun.
-    CallDefun(Srcloc, SExp),
+    /// The expression invokes an env defun or a constant containing a standalone program.
+    /// The bool indicates whether the target expects the caller's left env.
+    CallDefun(Srcloc, SExp, bool),
     /// The expression expands and inline function.
     CallInline(Srcloc, InlineFunction),
     /// The expression addresses a clvm primitive (such as a, c, f, =)

--- a/src/compiler/optimize/mod.rs
+++ b/src/compiler/optimize/mod.rs
@@ -442,7 +442,7 @@ pub fn optimize_expr(
                     // A function is constant if its body is a constant
                     // expression or all its arguments are constant and
                     // its body doesn't include an environment reference.
-                    Callable::CallDefun(l, _target) => {
+                    Callable::CallDefun(l, _target, _) => {
                         if let Some(constant_invocation) = constant_fun_result(
                             allocator,
                             opts.clone(),

--- a/src/compiler/preprocessor/mod.rs
+++ b/src/compiler/preprocessor/mod.rs
@@ -507,7 +507,7 @@ impl Preprocessor {
                 name: name.to_vec(),
                 kw: None,
                 nl: srcloc.clone(),
-                tabled: true,
+                tabled: false,
                 body: Rc::new(BodyForm::Quoted(s)),
             })
             .to_sexp()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the blanket `d.tabled = false` reset from module constant modernization.
- Keep synthesized imported module/program constants inline so imports continue to behave as values.
- Distinguish in-module defun calls from constants that contain standalone exported programs so imported function calls do not receive an extra left environment.
- Allow already-computed tabled constants to be emitted as literal values when they are no longer present in the current standalone env shape.
- Address clippy's `collapsible_match` warnings in the updated constant modernization helpers.

## Investigation
- With `d.tabled = false` removed, `test_two_program_import_include` failed at runtime with `InvalidOpArg(..., "Requires Int Argument: *")`.
- The intermediate module imported `THREE` from `two-outputs-constant` and exported `G`; preserving `tabled` caused `G`'s standalone program to retain a left-env dependency for `THREE`.
- When the outer module imported `G`, call generation treated the imported standalone program like a local env defun and prepended the caller's left env. That shifted `G`'s expected argument/env shape, so `*` received the wrong pair-shaped value instead of integer `3`.
- A related exported-constant path also needed direct lookup of computed tabled constants after the export helper is forced inline for standalone component generation.
- CI clippy failed on the first removal commit because the deleted assignment left `modernize_constants` in a nested `if`/`match` shape; the latest commit rewrites those arms with guards.

## Tests
- `cargo clippy --workspace -- -D warnings`
- `cargo test compiler::modules`
- `cargo test test_two_program_import_include -- --nocapture`
- `cargo test test_program_exporting_constant_from_program -- --nocapture`
- `cargo test test_legal_all_tabled -- --nocapture`
- `cargo test test_export_foreign_constant -- --nocapture`
- `cargo test test_two_outputs_include_exports -- --nocapture`
- `cargo test test_export_constant -- --nocapture`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2edc7955-ede9-4854-9abf-da9ea8a4fd94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2edc7955-ede9-4854-9abf-da9ea8a4fd94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

