### PR TITLE
Preserve tabled constants during module modernization

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -219,7 +219,6 @@ fn modernize_constants(helpers: &mut [HelperForm], standalone_constants: &HashSe
         match h {
             HelperForm::Defconstant(d) => {
                 // Ensure that we upgrade the constant type.
-                d.tabled = false;
                 if standalone_constants.contains(&d.name) {
                     d.kind = ConstantKind::Module;
                 }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -217,11 +217,9 @@ pub fn find_exported_helper(
 fn modernize_constants(helpers: &mut [HelperForm], standalone_constants: &HashSet<Vec<u8>>) {
     for h in helpers.iter_mut() {
         match h {
-            HelperForm::Defconstant(d) => {
+            HelperForm::Defconstant(d) if standalone_constants.contains(&d.name) => {
                 // Ensure that we upgrade the constant type.
-                if standalone_constants.contains(&d.name) {
-                    d.kind = ConstantKind::Module;
-                }
+                d.kind = ConstantKind::Module;
             }
             HelperForm::Defnamespace(ns) => {
                 modernize_constants(&mut ns.helpers, standalone_constants);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the module modernization assignment that forced all constants to non-tabled.
- Collapse the remaining constant modernization branch into a guarded match arm to satisfy clippy.

## Investigation notes
- The expected failures reproduce after preserving tabled constants:
  - `cargo test test_export_foreign_constant -- --nocapture`
  - `cargo test test_program_exporting_constant_from_program -- --nocapture`
- Temporary trace output around `start_codegen`, `compute_env_shape`, and nil-env mode showed the common phase keeps the tabled constant in the environment shape:
  - `test-data.one.QUOTED_ONE`: `CommonPhase(false)` env shape `(test-data.one.QUOTED_ONE)`
  - `programs.single-constant.C`: `CommonPhase(false)` env shape `(programs.single-constant.C)`
- In the following standalone pass, `compile_module` creates `StandalonePhaseInfo` with `empty_common_phase: !common_phase_functions`. For these constant-only modules, `common_phase_functions` is `false`, so `empty_common_phase` is `true` even though the common env is not empty.
- `compute_env_shape` then takes the `StandalonePhase` `empty_common_phase` branch. Since the tabled constant is already present in `sp.env`, it is excluded from `extra_env_data`, and the branch returns an empty left environment `(())` for nil args. Nil-env mode subsequently rewrites `(())` to `()`.
- Assertion check used during investigation: `empty_common_phase` should imply `collect_env_names(sp.env).is_empty()`. It failed with the live tabled constant still in `sp.env`, confirming the invariant violation.

## Exact cause
`empty_common_phase` is derived solely from whether the common phase has defuns, not whether the common phase environment has live tabled constants. That was masked by `d.tabled = false`; once tabled constants are preserved, constant-only common phases can still have a non-empty environment, but standalone codegen treats it as empty and drops the tabled constants from the environment shape.

## Verification
- `cargo clippy --workspace -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f132738-0971-4410-b42b-08c5ef8ba988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f132738-0971-4410-b42b-08c5ef8ba988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

