### PR TITLE
Add deinline timing diagnostics

### DIFF
--- a/.github/workflows/chia-gaming-tests.yml
+++ b/.github/workflows/chia-gaming-tests.yml
@@ -72,7 +72,35 @@ jobs:
         ./tools/run-clsp-tests.sh
         echo deinline diagnostics
         if [ -f deinline-diagnostics.tsv ]; then
-          cat deinline-diagnostics.tsv
+          python3 - <<'PY'
+        import csv
+        from pathlib import Path
+
+        path = Path("deinline-diagnostics.tsv")
+        with path.open(newline="") as diagnostics:
+            rows = list(csv.DictReader(diagnostics, delimiter="\t"))
+
+        print(f"deinline diagnostic rows: {len(rows)}")
+        interesting = [
+            row
+            for row in rows
+            if int(row["cache_attempts"]) > 0 or float(row["elapsed_ms"]) >= 1.0
+        ]
+        interesting.sort(key=lambda row: float(row["elapsed_ms"]), reverse=True)
+        for row in interesting[:50]:
+            print(
+                "\t".join(
+                    [
+                        row["elapsed_ms"],
+                        row["cache_hit_percent"],
+                        row["cache_attempts"],
+                        row["helper_count"],
+                        row["program"],
+                        row["compileform_loc"],
+                    ]
+                )
+            )
+        PY
         else
           echo "deinline-diagnostics.tsv was not generated"
         fi

--- a/.github/workflows/chia-gaming-tests.yml
+++ b/.github/workflows/chia-gaming-tests.yml
@@ -49,11 +49,14 @@ jobs:
         ./tools/check-build-deps.sh --install --yes
 
     - name: Rebuild chia-gaming chialisp
+      env:
+        CHIALISP_DEINLINE_DIAGNOSTICS: deinline-diagnostics.tsv
       run: |
         cp support/chia-gaming-build.rs chia-gaming/build.rs
         cp support/chia-gaming-run-clsp-tests.sh chia-gaming/tools/run-clsp-tests.sh
         chmod +x chia-gaming/tools/run-clsp-tests.sh
         cd chia-gaming
+        rm -f deinline-diagnostics.tsv
         for file in $(find clsp -name \*.hex) ; do rm $file ; done
         cargo build
         echo generated hex files
@@ -62,6 +65,14 @@ jobs:
         rm -rf build.rs
 
     - name: Run chia-gaming chialisp tests
+      env:
+        CHIALISP_DEINLINE_DIAGNOSTICS: deinline-diagnostics.tsv
       run: |
         cd chia-gaming
         ./tools/run-clsp-tests.sh
+        echo deinline diagnostics
+        if [ -f deinline-diagnostics.tsv ]; then
+          cat deinline-diagnostics.tsv
+        else
+          echo "deinline-diagnostics.tsv was not generated"
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__
 .pytest_cache
 main.sym
 venv/
+.chialisp/

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -18,6 +18,7 @@ use crate::compiler::comptypes::{
     LetFormKind, ModulePhase, PrimaryCodegen, RawCallSpec, SyntheticType,
 };
 use crate::compiler::debug::{build_swap_table_mut, relabel};
+use crate::compiler::diskcache::{set_function_cache_element, try_function_from_cache};
 use crate::compiler::evaluate::{is_apply_atom, Evaluator, EVAL_STACK_LIMIT};
 use crate::compiler::frontend::{compile_bodyform, make_provides_set};
 use crate::compiler::gensym::gensym;
@@ -26,7 +27,7 @@ use crate::compiler::lambda::lambda_codegen;
 use crate::compiler::optimize::depgraph::{DepgraphOptions, FunctionDependencyGraph};
 use crate::compiler::prims::{primapply, primcons, primquote};
 use crate::compiler::runtypes::RunFailure;
-use crate::compiler::sexp::{decode_string, printable, SExp};
+use crate::compiler::sexp::{decode_string, enlist, printable, SExp};
 use crate::compiler::srcloc::Srcloc;
 use crate::compiler::FunctionEntry;
 use crate::compiler::StartOfCodegenOptimization;
@@ -1252,24 +1253,16 @@ fn get_depended_on_forms(
 /// Compute a cache key for `helper`'s generated CLVM code inside `compiler`.
 ///
 /// **Preimage contents** (hashed via `sha256tree`):
-///   `(helper.to_sexp() . depended_on_forms)`
+///   `(funcache-v2 compile-settings helper-dependency-form)`
 /// where `depended_on_forms` is the s-expression representation of every
 /// inline, constant, and tabled-constant body that `helper` transitively
 /// depends on (via the dependency graph), plus the env shape filtered to
 /// only the names in the dependency closure.
 ///
-/// **Inputs NOT in the preimage** (callers must hold these constant for the
-/// lifetime of a single `Funcache` instance):
-///   - `opts.dialect()` (stepping, strict, int_fix)
-///   - `opts.module_phase()`
-///   - `compiler.parentfns`, `compiler.left_env`
-///   - Optimizer strategy
-///
-/// This is safe today because `Funcache` is created fresh inside each
-/// `deinline_opt` call, where all of the above are constant. If the cache is
-/// ever made longer-lived (e.g. across compilation units), those inputs must
-/// be added to the preimage.
+/// The compile settings are included because function cache entries can now be
+/// persisted across compiler invocations.
 pub(crate) fn get_function_cache_key(
+    opts: Rc<dyn CompilerOpts>,
     compiler: &PrimaryCodegen,
     dependency_graph: &FunctionDependencyGraph,
     helper: &HelperForm,
@@ -1285,7 +1278,28 @@ pub(crate) fn get_function_cache_key(
     );
     let depended_on =
         get_depended_on_forms(compiler, helper.loc(), filtered_env.clone(), &depends_on);
-    let hashable = Rc::new(SExp::Cons(helper.loc(), helper.to_sexp(), depended_on));
+    let helper_dependency_form = Rc::new(SExp::Cons(helper.loc(), helper.to_sexp(), depended_on));
+    let loc = helper.loc();
+    let atom = |s: String| Rc::new(SExp::Atom(loc.clone(), s.into_bytes()));
+    let mut parentfns: Vec<String> = compiler.parentfns.iter().map(hex::encode).collect();
+    parentfns.sort();
+    let hashable = Rc::new(enlist(
+        loc.clone(),
+        &[
+            atom("funcache-v2".to_string()),
+            atom(format!("dialect={:?}", opts.dialect())),
+            atom(format!("opts_module_phase={:?}", opts.module_phase())),
+            atom(format!("compiler_module_phase={:?}", compiler.module_phase)),
+            atom(format!("optimize={}", opts.optimize())),
+            atom(format!("frontend_opt={}", opts.frontend_opt())),
+            atom(format!("stdenv={}", opts.stdenv())),
+            atom(format!("in_defun={}", opts.in_defun())),
+            atom(format!("disassembly_ver={:?}", opts.disassembly_ver())),
+            atom(format!("left_env={}", compiler.left_env)),
+            atom(format!("parentfns={}", parentfns.join(","))),
+            helper_dependency_form,
+        ],
+    ));
     sha256tree(hashable)
 }
 
@@ -1320,7 +1334,7 @@ fn codegen_(
                 let cache_key = dependency_graph
                     .as_ref()
                     .filter(|_| context.funcache.is_some())
-                    .map(|d| get_function_cache_key(compiler, d, h));
+                    .map(|d| get_function_cache_key(opts.clone(), compiler, d, h));
 
                 let cached_code = if let (Some(key), Some(fc)) =
                     (cache_key.as_ref(), context.funcache.as_mut())
@@ -1330,10 +1344,23 @@ fn codegen_(
                             fc.hits += 1;
                             Some(code)
                         }
-                        None => {
-                            fc.misses += 1;
-                            None
-                        }
+                        None => match try_function_from_cache(opts.clone(), &h.loc(), key) {
+                            Some(code) => {
+                                fc.hits += 1;
+                                fc.function_outputs.insert(
+                                    key.to_vec(),
+                                    FunctionEntry {
+                                        code: code.clone(),
+                                        name: h.name().to_vec(),
+                                    },
+                                );
+                                Some(code)
+                            }
+                            None => {
+                                fc.misses += 1;
+                                None
+                            }
+                        },
                     }
                 } else {
                     None
@@ -1416,12 +1443,13 @@ fn codegen_(
 
                 if let (Some(fc), Some(hash)) = (&mut context.funcache, cache_key) {
                     fc.function_outputs.insert(
-                        hash,
+                        hash.clone(),
                         FunctionEntry {
                             code: code.clone(),
                             name: h.name().to_vec(),
                         },
                     );
+                    set_function_cache_element(opts.clone(), &hash, code.borrow());
                 }
 
                 Ok(compiler.add_defun(

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -1322,12 +1322,24 @@ fn codegen_(
                     .filter(|_| context.funcache.is_some())
                     .map(|d| get_function_cache_key(compiler, d, h));
 
-                if let Some(code) = cache_key.as_ref().and_then(|key| {
-                    context
-                        .funcache
-                        .as_ref()
-                        .and_then(|c| c.function_outputs.get(key).map(|e| e.code.clone()))
-                }) {
+                let cached_code = if let (Some(key), Some(fc)) =
+                    (cache_key.as_ref(), context.funcache.as_mut())
+                {
+                    match fc.function_outputs.get(key).map(|e| e.code.clone()) {
+                        Some(code) => {
+                            fc.hits += 1;
+                            Some(code)
+                        }
+                        None => {
+                            fc.misses += 1;
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                if let Some(code) = cached_code {
                     if !allow_redef {
                         check_already_present(code.clone())?;
                     }

--- a/src/compiler/diskcache.rs
+++ b/src/compiler/diskcache.rs
@@ -2,7 +2,8 @@ use std::rc::Rc;
 
 use crate::compiler::clvm::sha256tree_from_atom;
 use crate::compiler::comptypes::{CompileErr, CompileForm, CompilerOpts};
-use crate::compiler::sexp::decode_string;
+use crate::compiler::sexp::{decode_string, parse_sexp, SExp};
+use crate::compiler::srcloc::Srcloc;
 
 fn cache_key(cf: &CompileForm) -> String {
     let mut include_fingerprints = Vec::new();
@@ -65,6 +66,40 @@ pub fn set_cache_element(
 #[cfg(test)]
 pub fn module_cache_key_hex(cf: &CompileForm) -> String {
     cache_key(cf)
+}
+
+pub(crate) fn function_cache_path(function_cache_key: &[u8]) -> String {
+    let key = hex::encode(sha256tree_from_atom(function_cache_key));
+    format!(".chialisp/function-cache/{key}.clvm")
+}
+
+pub(crate) fn try_function_from_cache(
+    opts: Rc<dyn CompilerOpts>,
+    loc: &Srcloc,
+    function_cache_key: &[u8],
+) -> Option<Rc<SExp>> {
+    let cache_path = function_cache_path(function_cache_key);
+    let (_, data) = opts.read_new_file(loc.file.to_string(), cache_path).ok()?;
+    let parsed = parse_sexp(
+        Srcloc::start("*function-cache*"),
+        decode_string(&data).bytes(),
+    )
+    .ok()?;
+    if parsed.len() == 1 {
+        Some(parsed[0].clone())
+    } else {
+        None
+    }
+}
+
+pub(crate) fn set_function_cache_element(
+    opts: Rc<dyn CompilerOpts>,
+    function_cache_key: &[u8],
+    code: &SExp,
+) {
+    let cache_path = function_cache_path(function_cache_key);
+    opts.write_new_file(&cache_path, code.to_string().as_bytes())
+        .ok();
 }
 
 #[cfg(test)]
@@ -140,6 +175,18 @@ mod tests {
         assert_ne!(
             k,
             "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a"
+        );
+    }
+
+    #[test]
+    fn function_cache_path_hashes_function_key() {
+        let key = b"function cache key";
+        assert_eq!(
+            function_cache_path(key),
+            format!(
+                ".chialisp/function-cache/{}.clvm",
+                hex::encode(sha256tree_from_atom(key))
+            )
         );
     }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -105,6 +105,8 @@ pub struct FunctionEntry {
 #[derive(Default)]
 pub struct Funcache {
     pub function_outputs: HashMap<Vec<u8>, FunctionEntry>,
+    pub hits: u64,
+    pub misses: u64,
 }
 
 /// An object which represents the standard set of mutable items passed down the

--- a/src/compiler/optimize/deinline.rs
+++ b/src/compiler/optimize/deinline.rs
@@ -109,7 +109,7 @@ fn write_deinline_diagnostic(
 
     if write_header {
         let header = concat!(
-            "program\tmodule_phase\tcompileform_loc\thelapsed_ms\t",
+            "program\tmodule_phase\tcompileform_loc\telapsed_ms\t",
             "cache_hits\tcache_misses\tcache_attempts\tcache_hit_percent\t",
             "cache_entries_added\tcache_entries_total\thelper_count\t",
             "initial_metric\tfinal_metric\n"

--- a/src/compiler/optimize/deinline.rs
+++ b/src/compiler/optimize/deinline.rs
@@ -13,6 +13,7 @@ use crate::compiler::{
 };
 
 const DEINLINE_DIAGNOSTICS_ENV: &str = "CHIALISP_DEINLINE_DIAGNOSTICS";
+const DEINLINE_DIAGNOSTICS_SKIPPED_ENV: &str = "CHIALISP_DEINLINE_DIAGNOSTICS_SKIPPED";
 const DEINLINE_DIAGNOSTICS_FILE: &str = "deinline-diagnostics.tsv";
 
 #[derive(Clone, Copy, Default)]
@@ -41,6 +42,12 @@ fn deinline_diagnostics_path() -> Option<String> {
     } else {
         Some(path)
     }
+}
+
+fn write_skipped_deinline_diagnostics() -> bool {
+    env::var(DEINLINE_DIAGNOSTICS_SKIPPED_ENV)
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }
 
 fn diagnostics_field(value: &str) -> String {
@@ -182,17 +189,19 @@ pub fn deinline_opt(
 
     // Short circuit return: no helpers.
     if compileform.helpers.is_empty() {
-        let cache_snapshot = funcache_snapshot(context.funcache.as_ref());
-        write_deinline_diagnostic(
-            diagnostics_path.as_deref(),
-            opts,
-            &compileform,
-            diagnostics_started_at.elapsed(),
-            cache_snapshot,
-            cache_snapshot,
-            None,
-            None,
-        );
+        if write_skipped_deinline_diagnostics() {
+            let cache_snapshot = funcache_snapshot(context.funcache.as_ref());
+            write_deinline_diagnostic(
+                diagnostics_path.as_deref(),
+                opts,
+                &compileform,
+                diagnostics_started_at.elapsed(),
+                cache_snapshot,
+                cache_snapshot,
+                None,
+                None,
+            );
+        }
         return Ok(compileform);
     }
 

--- a/src/compiler/optimize/deinline.rs
+++ b/src/compiler/optimize/deinline.rs
@@ -1,5 +1,9 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::env;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 use crate::compiler::codegen::codegen;
 use crate::compiler::optimize::depgraph::{DepgraphKind, DepgraphOptions, FunctionDependencyGraph};
@@ -7,6 +11,128 @@ use crate::compiler::optimize::{sexp_scale, SyntheticType};
 use crate::compiler::{
     BasicCompileContext, CompileErr, CompileForm, CompilerOpts, Funcache, HelperForm,
 };
+
+const DEINLINE_DIAGNOSTICS_ENV: &str = "CHIALISP_DEINLINE_DIAGNOSTICS";
+const DEINLINE_DIAGNOSTICS_FILE: &str = "deinline-diagnostics.tsv";
+
+#[derive(Clone, Copy, Default)]
+struct FuncacheSnapshot {
+    hits: u64,
+    misses: u64,
+    entries: usize,
+}
+
+fn funcache_snapshot(funcache: Option<&Funcache>) -> FuncacheSnapshot {
+    funcache.map_or_else(FuncacheSnapshot::default, |fc| FuncacheSnapshot {
+        hits: fc.hits,
+        misses: fc.misses,
+        entries: fc.function_outputs.len(),
+    })
+}
+
+fn deinline_diagnostics_path() -> Option<String> {
+    let path = env::var(DEINLINE_DIAGNOSTICS_ENV).ok()?;
+    if path == "0" || path.eq_ignore_ascii_case("false") {
+        return None;
+    }
+
+    if path.is_empty() || path == "1" || path.eq_ignore_ascii_case("true") {
+        Some(DEINLINE_DIAGNOSTICS_FILE.to_string())
+    } else {
+        Some(path)
+    }
+}
+
+fn diagnostics_field(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+fn format_hit_percent(hits: u64, misses: u64) -> String {
+    let attempts = hits + misses;
+    if attempts == 0 {
+        "0.00".to_string()
+    } else {
+        format!("{:.2}", hits as f64 * 100.0 / attempts as f64)
+    }
+}
+
+fn write_deinline_diagnostic(
+    path: Option<&str>,
+    opts: Rc<dyn CompilerOpts>,
+    compileform: &CompileForm,
+    elapsed: Duration,
+    cache_before: FuncacheSnapshot,
+    cache_after: FuncacheSnapshot,
+    initial_metric: Option<u64>,
+    final_metric: Option<u64>,
+) {
+    let Some(path) = path else {
+        return;
+    };
+
+    let cache_hits = cache_after.hits.saturating_sub(cache_before.hits);
+    let cache_misses = cache_after.misses.saturating_sub(cache_before.misses);
+    let cache_attempts = cache_hits + cache_misses;
+    let cache_entries_added = cache_after.entries.saturating_sub(cache_before.entries);
+    let module_phase = opts
+        .module_phase()
+        .map(|phase| format!("{phase:?}"))
+        .unwrap_or_else(|| "program".to_string());
+    let initial_metric = initial_metric
+        .map(|m| m.to_string())
+        .unwrap_or_else(|| "n/a".to_string());
+    let final_metric = final_metric
+        .map(|m| m.to_string())
+        .unwrap_or_else(|| "n/a".to_string());
+
+    let write_header = std::fs::metadata(path)
+        .map(|metadata| metadata.len() == 0)
+        .unwrap_or(true);
+    let mut file = match OpenOptions::new().create(true).append(true).open(path) {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!("failed to open deinline diagnostics file {path}: {e}");
+            return;
+        }
+    };
+
+    if write_header {
+        let header = concat!(
+            "program\tmodule_phase\tcompileform_loc\thelapsed_ms\t",
+            "cache_hits\tcache_misses\tcache_attempts\tcache_hit_percent\t",
+            "cache_entries_added\tcache_entries_total\thelper_count\t",
+            "initial_metric\tfinal_metric\n"
+        );
+        if let Err(e) = file.write_all(header.as_bytes()) {
+            eprintln!("failed to write deinline diagnostics header to {path}: {e}");
+            return;
+        }
+    }
+
+    let row = format!(
+        "{}\t{}\t{}\t{:.3}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+        diagnostics_field(&opts.filename()),
+        diagnostics_field(&module_phase),
+        diagnostics_field(&compileform.loc.to_string()),
+        elapsed.as_secs_f64() * 1000.0,
+        cache_hits,
+        cache_misses,
+        cache_attempts,
+        format_hit_percent(cache_hits, cache_misses),
+        cache_entries_added,
+        cache_after.entries,
+        compileform.helpers.len(),
+        initial_metric,
+        final_metric
+    );
+    if let Err(e) = file.write_all(row.as_bytes()) {
+        eprintln!("failed to write deinline diagnostics row to {path}: {e}");
+    }
+}
 
 // Find the roots for the given function.
 fn find_roots(
@@ -51,14 +177,29 @@ pub fn deinline_opt(
     opts: Rc<dyn CompilerOpts>,
     mut compileform: CompileForm,
 ) -> Result<CompileForm, CompileErr> {
+    let diagnostics_path = deinline_diagnostics_path();
+    let diagnostics_started_at = Instant::now();
+
     // Short circuit return: no helpers.
     if compileform.helpers.is_empty() {
+        let cache_snapshot = funcache_snapshot(context.funcache.as_ref());
+        write_deinline_diagnostic(
+            diagnostics_path.as_deref(),
+            opts,
+            &compileform,
+            diagnostics_started_at.elapsed(),
+            cache_snapshot,
+            cache_snapshot,
+            None,
+            None,
+        );
         return Ok(compileform);
     }
 
     if context.funcache.is_none() {
         context.funcache = Some(Funcache::default());
     }
+    let cache_before = funcache_snapshot(context.funcache.as_ref());
 
     let is_module_compile = opts.module_phase().is_some();
     let depgraph = if is_module_compile {
@@ -75,6 +216,7 @@ pub fn deinline_opt(
     let mut best_compileform = compileform.clone();
     let generated_program = codegen(context, opts.clone(), Some(&depgraph), &best_compileform)?;
     let mut metric = sexp_scale(&generated_program);
+    let initial_metric = metric;
 
     let flip_helper = |h: &mut HelperForm| {
         if let HelperForm::Defun(inline, defun) = h {
@@ -271,6 +413,17 @@ pub fn deinline_opt(
             }
         }
     }
+
+    write_deinline_diagnostic(
+        diagnostics_path.as_deref(),
+        opts,
+        &best_compileform,
+        diagnostics_started_at.elapsed(),
+        cache_before,
+        funcache_snapshot(context.funcache.as_ref()),
+        Some(initial_metric),
+        Some(metric),
+    );
 
     Ok(best_compileform)
 }

--- a/src/compiler/optimize/deinline.rs
+++ b/src/compiler/optimize/deinline.rs
@@ -23,6 +23,16 @@ struct FuncacheSnapshot {
     entries: usize,
 }
 
+struct DeinlineDiagnostic<'a> {
+    opts: Rc<dyn CompilerOpts>,
+    compileform: &'a CompileForm,
+    elapsed: Duration,
+    cache_before: FuncacheSnapshot,
+    cache_after: FuncacheSnapshot,
+    initial_metric: Option<u64>,
+    final_metric: Option<u64>,
+}
+
 fn funcache_snapshot(funcache: Option<&Funcache>) -> FuncacheSnapshot {
     funcache.map_or_else(FuncacheSnapshot::default, |fc| FuncacheSnapshot {
         hits: fc.hits,
@@ -67,32 +77,35 @@ fn format_hit_percent(hits: u64, misses: u64) -> String {
     }
 }
 
-fn write_deinline_diagnostic(
-    path: Option<&str>,
-    opts: Rc<dyn CompilerOpts>,
-    compileform: &CompileForm,
-    elapsed: Duration,
-    cache_before: FuncacheSnapshot,
-    cache_after: FuncacheSnapshot,
-    initial_metric: Option<u64>,
-    final_metric: Option<u64>,
-) {
+fn write_deinline_diagnostic(path: Option<&str>, diagnostic: DeinlineDiagnostic<'_>) {
     let Some(path) = path else {
         return;
     };
 
-    let cache_hits = cache_after.hits.saturating_sub(cache_before.hits);
-    let cache_misses = cache_after.misses.saturating_sub(cache_before.misses);
+    let cache_hits = diagnostic
+        .cache_after
+        .hits
+        .saturating_sub(diagnostic.cache_before.hits);
+    let cache_misses = diagnostic
+        .cache_after
+        .misses
+        .saturating_sub(diagnostic.cache_before.misses);
     let cache_attempts = cache_hits + cache_misses;
-    let cache_entries_added = cache_after.entries.saturating_sub(cache_before.entries);
-    let module_phase = opts
+    let cache_entries_added = diagnostic
+        .cache_after
+        .entries
+        .saturating_sub(diagnostic.cache_before.entries);
+    let module_phase = diagnostic
+        .opts
         .module_phase()
         .map(|phase| format!("{phase:?}"))
         .unwrap_or_else(|| "program".to_string());
-    let initial_metric = initial_metric
+    let initial_metric = diagnostic
+        .initial_metric
         .map(|m| m.to_string())
         .unwrap_or_else(|| "n/a".to_string());
-    let final_metric = final_metric
+    let final_metric = diagnostic
+        .final_metric
         .map(|m| m.to_string())
         .unwrap_or_else(|| "n/a".to_string());
 
@@ -122,17 +135,17 @@ fn write_deinline_diagnostic(
 
     let row = format!(
         "{}\t{}\t{}\t{:.3}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
-        diagnostics_field(&opts.filename()),
+        diagnostics_field(&diagnostic.opts.filename()),
         diagnostics_field(&module_phase),
-        diagnostics_field(&compileform.loc.to_string()),
-        elapsed.as_secs_f64() * 1000.0,
+        diagnostics_field(&diagnostic.compileform.loc.to_string()),
+        diagnostic.elapsed.as_secs_f64() * 1000.0,
         cache_hits,
         cache_misses,
         cache_attempts,
         format_hit_percent(cache_hits, cache_misses),
         cache_entries_added,
-        cache_after.entries,
-        compileform.helpers.len(),
+        diagnostic.cache_after.entries,
+        diagnostic.compileform.helpers.len(),
         initial_metric,
         final_metric
     );
@@ -193,13 +206,15 @@ pub fn deinline_opt(
             let cache_snapshot = funcache_snapshot(context.funcache.as_ref());
             write_deinline_diagnostic(
                 diagnostics_path.as_deref(),
-                opts,
-                &compileform,
-                diagnostics_started_at.elapsed(),
-                cache_snapshot,
-                cache_snapshot,
-                None,
-                None,
+                DeinlineDiagnostic {
+                    opts,
+                    compileform: &compileform,
+                    elapsed: diagnostics_started_at.elapsed(),
+                    cache_before: cache_snapshot,
+                    cache_after: cache_snapshot,
+                    initial_metric: None,
+                    final_metric: None,
+                },
             );
         }
         return Ok(compileform);
@@ -425,13 +440,15 @@ pub fn deinline_opt(
 
     write_deinline_diagnostic(
         diagnostics_path.as_deref(),
-        opts,
-        &best_compileform,
-        diagnostics_started_at.elapsed(),
-        cache_before,
-        funcache_snapshot(context.funcache.as_ref()),
-        Some(initial_metric),
-        Some(metric),
+        DeinlineDiagnostic {
+            opts,
+            compileform: &best_compileform,
+            elapsed: diagnostics_started_at.elapsed(),
+            cache_before,
+            cache_after: funcache_snapshot(context.funcache.as_ref()),
+            initial_metric: Some(initial_metric),
+            final_metric: Some(metric),
+        },
     );
 
     Ok(best_compileform)

--- a/src/tests/compiler/codegen_funcache.rs
+++ b/src/tests/compiler/codegen_funcache.rs
@@ -13,6 +13,7 @@ use crate::compiler::comptypes::{
     HelperForm,
 };
 use crate::compiler::dialect::AcceptedDialect;
+use crate::compiler::diskcache::function_cache_path;
 use crate::compiler::frontend::frontend;
 use crate::compiler::optimize::above22::Strategy23;
 use crate::compiler::optimize::depgraph::{DepgraphOptions, FunctionDependencyGraph};
@@ -405,14 +406,11 @@ fn test_codegen_function_cache() {
     assert_ne!(diffcc_h, old_h);
 }
 
-/// The cache key does NOT include the dialect or module_phase from opts; it only
-/// captures the helper s-expression, depended-on forms, and the filtered env shape.
-/// This is safe today because Funcache is scoped to a single deinline pass where
-/// dialect and module_phase are constant. This test documents that contract: the same
-/// helper compiled via two fresh Funcaches with different dialects produces different
-/// CLVM, proving the cache must not be shared across dialect boundaries.
+/// The cache key includes compile settings that can affect generated defun code.
+/// This is required now that function cache entries can be reused from disk across
+/// independent compiler invocations.
 #[test]
-fn funcache_key_same_across_dialects_different_output() {
+fn funcache_key_differs_across_dialects() {
     let program_src = "(mod (X) (defun F (Y) (+ Y 1)) (F X))";
 
     let make_opts = |stepping: i32, strict: bool| -> Rc<dyn CompilerOpts> {
@@ -468,14 +466,11 @@ fn funcache_key_same_across_dialects_different_output() {
     let cache_a = &ctx_a.funcache.as_ref().unwrap().function_outputs;
     let cache_b = &ctx_b.funcache.as_ref().unwrap().function_outputs;
 
-    // The cache keys should be the same because get_function_cache_key only hashes
-    // (helper.to_sexp(), filtered_env, depended_on_forms) -- not dialect/opts.
-    // This documents that the Funcache must not be shared across dialect boundaries.
     assert_eq!(cache_a.len(), cache_b.len());
     for k in cache_a.keys() {
         assert!(
-            cache_b.contains_key(k),
-            "cache key should be identical across dialects (documents that dialect is not in the preimage)"
+            !cache_b.contains_key(k),
+            "cache key should differ across dialects so persisted entries do not cross settings"
         );
     }
 
@@ -582,6 +577,102 @@ fn funcache_cold_vs_warm_roundtrip() {
             decode_string(&cold_entry.name)
         );
     }
+}
+
+#[test]
+fn funcache_reuses_entries_from_disk() {
+    let orig_opts: Rc<dyn CompilerOpts> =
+        Rc::new(DefaultCompilerOpts::new(&"*disk-roundtrip*".to_string()));
+    let opts: Rc<dyn CompilerOpts> = orig_opts
+        .set_search_paths(&["resources/tests/module".to_string(), ".".to_string()])
+        .set_stdenv(false)
+        .set_dialect(AcceptedDialect {
+            stepping: Some(25),
+            strict: true,
+            int_fix: true,
+            extra_numeric_constants: false,
+        });
+    let fs_opts = TestModuleCompilerOpts::new(opts.clone());
+    let opts: Rc<dyn CompilerOpts> = Rc::new(fs_opts.clone());
+    let (_, content) = opts
+        .read_new_file(
+            opts.filename(),
+            "resources/tests/module/cache-test-1.clsp".to_string(),
+        )
+        .expect("read");
+    let parsed =
+        parse_sexp(Srcloc::start(&opts.filename()), content.iter().cloned()).expect("parse");
+    let program = frontend(opts.clone(), &parsed).expect("frontend");
+    let (mut compileform, exports) = if let FrontendOutput::Module(cf, ex) = program {
+        (cf, ex)
+    } else {
+        panic!("expected Module");
+    };
+    (compileform.args, compileform.exp) = if let Export::MainProgram(ep) = &exports[0] {
+        (ep.args.clone(), ep.expr.clone())
+    } else {
+        panic!("expected MainProgram export");
+    };
+    compileform = rename_args_compileform(&compileform).unwrap();
+    let desugared = do_desugar(opts.clone(), &compileform).unwrap();
+    let depgraph = FunctionDependencyGraph::new_with_options(
+        &desugared,
+        DepgraphOptions {
+            with_constants: true,
+        },
+    );
+    let runner = Rc::new(DefaultProgramRunner::new());
+
+    let mut cold = BasicCompileContext::new(
+        Allocator::new(),
+        runner.clone(),
+        HashMap::new(),
+        Box::new(Strategy23 {}),
+    );
+    cold.funcache = Some(Funcache::default());
+    let out_cold =
+        codegen(&mut cold, opts.clone(), Some(&depgraph), &desugared).expect("cold codegen");
+    let function_cache_files: Vec<String> = fs_opts
+        .list_written_files()
+        .into_iter()
+        .filter(|path| path.starts_with(".chialisp/function-cache/"))
+        .collect();
+    assert!(
+        !function_cache_files.is_empty(),
+        "cold codegen should persist function cache entries"
+    );
+    for key in cold
+        .funcache
+        .as_ref()
+        .expect("cold cache")
+        .function_outputs
+        .keys()
+    {
+        assert!(
+            function_cache_files.contains(&function_cache_path(key)),
+            "persisted cache files should be named from the sha256tree hash of the function cache key"
+        );
+    }
+
+    let mut warm = BasicCompileContext::new(
+        Allocator::new(),
+        runner,
+        HashMap::new(),
+        Box::new(Strategy23 {}),
+    );
+    warm.funcache = Some(Funcache::default());
+    let out_warm =
+        codegen(&mut warm, opts.clone(), Some(&depgraph), &desugared).expect("warm codegen");
+    let warm_cache = warm.funcache.as_ref().expect("warm cache");
+    assert!(
+        warm_cache.hits > 0,
+        "warm codegen should count persisted function cache hits"
+    );
+    assert_eq!(
+        warm_cache.misses, 0,
+        "warm codegen should not miss when all persisted entries exist"
+    );
+    assert_eq!(out_cold.to_string(), out_warm.to_string());
 }
 
 /// `Funcache` is only consulted when a `FunctionDependencyGraph` is passed into `codegen`.

--- a/src/tests/compiler/codegen_funcache.rs
+++ b/src/tests/compiler/codegen_funcache.rs
@@ -555,6 +555,8 @@ fn funcache_cold_vs_warm_roundtrip() {
     );
     ctx_warm.funcache = Some(Funcache {
         function_outputs: cold_cache.clone(),
+        hits: 0,
+        misses: 0,
     });
     let out_warm =
         codegen(&mut ctx_warm, opts.clone(), Some(&depgraph), &desugared).expect("codegen warm");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add opt-in deinline timing diagnostics written as TSV output in the current working directory
- track function cache hits and misses to report cache hit percentage per deinline pass
- keep skipped/no-helper rows available via an explicit diagnostics env var while keeping workflow output focused on active deinline work
- enable diagnostics in the Chia Gaming workflow and print a compact slow-pass summary
- persist function-cache entries under `.chialisp/function-cache/` using a `sha256tree` hash of the function cache key in each filename
- include compile settings in function cache keys so persisted entries do not cross dialect/module-phase boundaries
- update function-cache tests for disk persistence and explicit setup for the new counters

## Testing
- `cargo fmt --all`
- `cargo test codegen_funcache -- --nocapture`
- `cargo test diskcache -- --nocapture`
- `cargo clippy --workspace -- -D warnings`
- `CHIALISP_DEINLINE_DIAGNOSTICS=deinline-two-program.tsv CHIALISP_DEINLINE_DIAGNOSTICS_SKIPPED=1 cargo test test_two_program_import_include -- --nocapture`
- Targeted Chia Gaming calpoker rebuild benchmark, after prebuilding Rust with `CHIALISP_NOCOMPILE=1` and limiting `chialisp.toml` to `calpoker-generate` and `calpoker-generate-v1`:
  - cold rebuild with empty `.chialisp`: `real 2002.01s`, diagnostics aggregate hit rate `51.63%`
  - warm rebuild preserving only `.chialisp/function-cache`: `real 1892.07s`, diagnostics aggregate hit rate `81.62%`
  - warm rebuild preserving all `.chialisp` cache data: `real 47.60s`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912bef1b-cb48-4b5d-9a75-4994b00b2432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912bef1b-cb48-4b5d-9a75-4994b00b2432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

