### PR TITLE
bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "chialisp"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "binascii",
  "chia-bls 0.42.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chialisp"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["Art Yerkes <art.yerkes@gmail.com>"]
 description = "tools for working with chialisp language; compiler, repl, python and wasm bindings"

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "chialisp"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "binascii",
  "chia-bls 0.42.0",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_tools_wasm"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "chialisp",
  "clvmr",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_wasm"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2018"
 authors = ["Art Yerkes <art.yerkes@gmail.com>"]
 description = "tools for working with chialisp language; compiler, repl, python and wasm bindings"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates crate/package version numbers and corresponding lockfiles, with no functional code changes.
> 
> **Overview**
> Bumps the crate versions from `0.4.4` to `0.4.5` for both `chialisp` and the WASM package `clvm_tools_wasm`, updating `Cargo.toml` and the associated `Cargo.lock` files accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dbe8587879c5ba98d53955002b3917a2ee73b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->