### PR TITLE
20260514 tricky cse assign

### DIFF
--- a/resources/tests/cse-complex-2.clsp
+++ b/resources/tests/cse-complex-2.clsp
@@ -1,0 +1,14 @@
+(mod (X)
+  (include *standard-cl-26*)
+
+  (defun F (X)
+    (strlen
+      (assign
+        A (+ X 1)
+        B (+ A 1)
+        (+ A 1)
+        )
+      )
+    )
+  (F X)
+  )

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -443,14 +443,13 @@ fn detect_common_cse_root(
     // Back it up to the body of a let binding or where we've removed a variable from
     // its own scope, which can be true if an assign form is not in a body position.
     for (idx, f) in target_path.iter().enumerate().rev() {
-        if f == &BodyformPathArc::BodyOf {
-            return Some(target_path.iter().take(idx + 1).cloned().collect());
-        }
-
         if let Some(ceiling) = ceiling {
             if ceiling.len() > idx || (ceiling.len() == idx && target_path[0..idx] != *ceiling) {
                 return None;
             }
+        }
+        if f == &BodyformPathArc::BodyOf {
+            return Some(target_path.iter().take(idx + 1).cloned().collect());
         }
     }
 

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -416,12 +416,12 @@ pub fn cse_classify_by_conditions(
         .collect()
 }
 
-fn detect_common_cse_root(instances: &[CSEInstance]) -> Vec<BodyformPathArc> {
+fn detect_common_cse_root(ceiling: Option<&Vec<BodyformPathArc>>, instances: &[CSEInstance]) -> Option<Vec<BodyformPathArc>> {
     // No instances, we can choose the root.
     let min_size = if let Some(m) = instances.iter().map(|i| i.path.len()).min() {
         m
     } else {
-        return Vec::new();
+        return Some(Vec::new());
     };
 
     let mut target_path = instances[0].path.clone();
@@ -437,15 +437,24 @@ fn detect_common_cse_root(instances: &[CSEInstance]) -> Vec<BodyformPathArc> {
         }
     }
 
-    // Back it up to the body of a let binding.
+    // Back it up to the body of a let binding or where we've removed a variable from
+    // its own scope, which can be true if an assign form is not in a body position.
     for (idx, f) in target_path.iter().enumerate().rev() {
         if f == &BodyformPathArc::BodyOf {
-            return target_path.iter().take(idx + 1).cloned().collect();
+            return Some(target_path.iter().take(idx + 1).cloned().collect());
+        }
+
+        if let Some(ceiling) = ceiling {
+            eprintln!("examining path {target_path:?}");
+            eprintln!("have ceiling {ceiling:?}");
+            if ceiling.len() > idx || (ceiling.len() == idx && target_path[0..idx] != *ceiling) {
+                return None;
+            }
         }
     }
 
     // No internal root if there was no let traversal.
-    Vec::new()
+    Some(Vec::new())
 }
 
 // Finds lambdas that contain CSE detection instances from the provided list.
@@ -587,6 +596,30 @@ fn merge_cse_binding(body: &BodyForm, binding: Rc<Binding>) -> BodyForm {
     body.clone()
 }
 
+fn match_bindings(bindings: &[Rc<Binding>], used_names: &HashSet<Vec<u8>>) -> HashSet<Vec<u8>> {
+    let mut new_set = HashSet::new();
+    for b in bindings.iter() {
+        match &b.pattern {
+            BindingPattern::Name(n) => {
+                let n_ref: &[u8] = &n;
+                if used_names.contains(n_ref) {
+                    new_set.insert(n.clone());
+                }
+            }
+            BindingPattern::Complex(p) => {
+                let names: HashSet<Vec<u8>> = collect_used_names_sexp(p.clone()).into_iter().collect();
+                for n in names.iter() {
+                    let n_ref: &[u8] = &n;
+                    if used_names.contains(n_ref) {
+                        new_set.insert(n.clone());
+                    }
+                }
+            }
+        }
+    }
+    new_set
+}
+
 type CSEReplacementTargetAndBindings<'a> = Vec<&'a (Vec<BodyformPathArc>, Vec<BindingStackEntry>)>;
 
 /// Given a bodyform, CSE analyze and produce a semantically equivalent bodyform
@@ -670,6 +703,37 @@ pub fn cse_optimize_bodyform(
                 ));
             };
 
+            let used_names: HashSet<Vec<u8>> = collect_used_names_bodyform(&prototype_instance).into_iter().collect();
+            // Detect the ceiling for this cse move.  It can only go to the body of a
+            // containing assignment form that binds a name it needs.
+            //
+            // This fixes a bug.  The requirements for causing the bug now are that one use
+            // of the common subexpression is in a binding that uses other bound values.
+            let mut ceiling = None;
+            for instance in d.instances.iter() {
+                for (idx, f) in instance.path.iter().enumerate().rev() {
+                    let want_path: Vec<BodyformPathArc> = instance.path.iter().take(idx).cloned().collect();
+                    if let Some(target) = retrieve_bodyform(&want_path, &function_body, &|b: &BodyForm| {
+                        b.clone()
+                    }) {
+                        if let BodyForm::Let(_, data) = &target {
+                            let names_provided_by_let_in_cse = match_bindings(&data.bindings, &used_names);
+                            eprintln!("{}", prototype_instance.to_sexp());
+                            eprintln!("{}", target.to_sexp());
+                            for n in names_provided_by_let_in_cse.iter() {
+                                eprintln!("- {}", decode_string(n));
+                            }
+                            if !names_provided_by_let_in_cse.is_empty() {
+                                let mut top_possible_body = want_path;
+                                top_possible_body.push(BodyformPathArc::BodyOf);
+                                ceiling = Some(top_possible_body);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
             // We'll assign a fresh variable for each of the detections
             // that are applicable now.
             let new_variable_name = gensym(b"cse".to_vec());
@@ -692,7 +756,14 @@ pub fn cse_optimize_bodyform(
 
             // Detect the root of the CSE as the innermost expression that covers
             // all uses.
-            let replace_path = detect_common_cse_root(&d.instances);
+            let replace_path =
+                match detect_common_cse_root(ceiling.as_ref(), &d.instances) {
+                    Some(rp) => rp,
+                    None => {
+                        // Can't do anything with this if there was no common root.
+                        continue;
+                    }
+                };
 
             // Route the captured repeated subexpression into intervening lambdas.
             // This means that the lambdas will gain a capture on the left side of

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -416,7 +416,10 @@ pub fn cse_classify_by_conditions(
         .collect()
 }
 
-fn detect_common_cse_root(ceiling: Option<&Vec<BodyformPathArc>>, instances: &[CSEInstance]) -> Option<Vec<BodyformPathArc>> {
+fn detect_common_cse_root(
+    ceiling: Option<&Vec<BodyformPathArc>>,
+    instances: &[CSEInstance],
+) -> Option<Vec<BodyformPathArc>> {
     // No instances, we can choose the root.
     let min_size = if let Some(m) = instances.iter().map(|i| i.path.len()).min() {
         m
@@ -445,8 +448,6 @@ fn detect_common_cse_root(ceiling: Option<&Vec<BodyformPathArc>>, instances: &[C
         }
 
         if let Some(ceiling) = ceiling {
-            eprintln!("examining path {target_path:?}");
-            eprintln!("have ceiling {ceiling:?}");
             if ceiling.len() > idx || (ceiling.len() == idx && target_path[0..idx] != *ceiling) {
                 return None;
             }
@@ -601,15 +602,16 @@ fn match_bindings(bindings: &[Rc<Binding>], used_names: &HashSet<Vec<u8>>) -> Ha
     for b in bindings.iter() {
         match &b.pattern {
             BindingPattern::Name(n) => {
-                let n_ref: &[u8] = &n;
+                let n_ref: &[u8] = n;
                 if used_names.contains(n_ref) {
                     new_set.insert(n.clone());
                 }
             }
             BindingPattern::Complex(p) => {
-                let names: HashSet<Vec<u8>> = collect_used_names_sexp(p.clone()).into_iter().collect();
+                let names: HashSet<Vec<u8>> =
+                    collect_used_names_sexp(p.clone()).into_iter().collect();
                 for n in names.iter() {
-                    let n_ref: &[u8] = &n;
+                    let n_ref: &[u8] = n;
                     if used_names.contains(n_ref) {
                         new_set.insert(n.clone());
                     }
@@ -703,7 +705,9 @@ pub fn cse_optimize_bodyform(
                 ));
             };
 
-            let used_names: HashSet<Vec<u8>> = collect_used_names_bodyform(&prototype_instance).into_iter().collect();
+            let used_names: HashSet<Vec<u8>> = collect_used_names_bodyform(&prototype_instance)
+                .into_iter()
+                .collect();
             // Detect the ceiling for this cse move.  It can only go to the body of a
             // containing assignment form that binds a name it needs.
             //
@@ -711,18 +715,15 @@ pub fn cse_optimize_bodyform(
             // of the common subexpression is in a binding that uses other bound values.
             let mut ceiling = None;
             for instance in d.instances.iter() {
-                for (idx, f) in instance.path.iter().enumerate().rev() {
-                    let want_path: Vec<BodyformPathArc> = instance.path.iter().take(idx).cloned().collect();
-                    if let Some(target) = retrieve_bodyform(&want_path, &function_body, &|b: &BodyForm| {
-                        b.clone()
-                    }) {
+                for (idx, _f) in instance.path.iter().enumerate().rev() {
+                    let want_path: Vec<BodyformPathArc> =
+                        instance.path.iter().take(idx).cloned().collect();
+                    if let Some(target) =
+                        retrieve_bodyform(&want_path, &function_body, &|b: &BodyForm| b.clone())
+                    {
                         if let BodyForm::Let(_, data) = &target {
-                            let names_provided_by_let_in_cse = match_bindings(&data.bindings, &used_names);
-                            eprintln!("{}", prototype_instance.to_sexp());
-                            eprintln!("{}", target.to_sexp());
-                            for n in names_provided_by_let_in_cse.iter() {
-                                eprintln!("- {}", decode_string(n));
-                            }
+                            let names_provided_by_let_in_cse =
+                                match_bindings(&data.bindings, &used_names);
                             if !names_provided_by_let_in_cse.is_empty() {
                                 let mut top_possible_body = want_path;
                                 top_possible_body.push(BodyformPathArc::BodyOf);
@@ -756,14 +757,13 @@ pub fn cse_optimize_bodyform(
 
             // Detect the root of the CSE as the innermost expression that covers
             // all uses.
-            let replace_path =
-                match detect_common_cse_root(ceiling.as_ref(), &d.instances) {
-                    Some(rp) => rp,
-                    None => {
-                        // Can't do anything with this if there was no common root.
-                        continue;
-                    }
-                };
+            let replace_path = match detect_common_cse_root(ceiling.as_ref(), &d.instances) {
+                Some(rp) => rp,
+                None => {
+                    // Can't do anything with this if there was no common root.
+                    continue;
+                }
+            };
 
             // Route the captured repeated subexpression into intervening lambdas.
             // This means that the lambdas will gain a capture on the left side of

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -718,18 +718,16 @@ pub fn cse_optimize_bodyform(
                 for (idx, _f) in instance.path.iter().enumerate().rev() {
                     let want_path: Vec<BodyformPathArc> =
                         instance.path.iter().take(idx).cloned().collect();
-                    if let Some(target) =
+                    if let Some(BodyForm::Let(_, data)) =
                         retrieve_bodyform(&want_path, &function_body, &|b: &BodyForm| b.clone())
                     {
-                        if let BodyForm::Let(_, data) = &target {
-                            let names_provided_by_let_in_cse =
-                                match_bindings(&data.bindings, &used_names);
-                            if !names_provided_by_let_in_cse.is_empty() {
-                                let mut top_possible_body = want_path;
-                                top_possible_body.push(BodyformPathArc::BodyOf);
-                                ceiling = Some(top_possible_body);
-                                break;
-                            }
+                        let names_provided_by_let_in_cse =
+                            match_bindings(&data.bindings, &used_names);
+                        if !names_provided_by_let_in_cse.is_empty() {
+                            let mut top_possible_body = want_path;
+                            top_possible_body.push(BodyformPathArc::BodyOf);
+                            ceiling = Some(top_possible_body);
+                            break;
                         }
                     }
                 }

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -454,7 +454,14 @@ fn detect_common_cse_root(
         }
     }
 
-    // No internal root if there was no let traversal.
+    // No internal root if there was no let traversal. If we found a ceiling,
+    // the top-level root would lift the CSE above a binding it depends on.
+    if let Some(ceiling) = ceiling {
+        if !ceiling.is_empty() {
+            return None;
+        }
+    }
+
     Some(Vec::new())
 }
 
@@ -940,4 +947,24 @@ pub fn cse_optimize_bodyform(
     }
 
     Ok(function_body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn common_cse_root_rejects_empty_path_above_ceiling() {
+        let ceiling = vec![BodyformPathArc::BodyOf];
+        let instances = vec![
+            CSEInstance {
+                path: vec![BodyformPathArc::LetBinding(1)],
+            },
+            CSEInstance {
+                path: vec![BodyformPathArc::BodyOf],
+            },
+        ];
+
+        assert_eq!(detect_common_cse_root(Some(&ceiling), &instances), None);
+    }
 }

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -2385,9 +2385,29 @@ fn test_cse_breakage_example() {
         program.clone(),
         "(())".to_string(),
     ])
-    .trim()
-    .to_string();
+        .trim()
+        .to_string();
     assert_eq!(run_result_11, "((a 3) (a 3) (a 3))");
+}
+
+#[test]
+fn test_cse_breakage_example_lift_outside_bindings() {
+    let filename = "resources/tests/cse-complex-2.clsp";
+    let program = do_basic_run(&vec!["run".to_string(), filename.to_string()])
+        .trim()
+        .to_string();
+
+    eprintln!(">> {program}");
+    assert!(program.starts_with("("));
+
+    let run_result_11 = do_basic_brun(&vec![
+        "brun".to_string(),
+        program.clone(),
+        "(())".to_string(),
+    ])
+        .trim()
+        .to_string();
+    assert_eq!(run_result_11, "1");
 }
 
 #[test]

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -2385,8 +2385,8 @@ fn test_cse_breakage_example() {
         program.clone(),
         "(())".to_string(),
     ])
-        .trim()
-        .to_string();
+    .trim()
+    .to_string();
     assert_eq!(run_result_11, "((a 3) (a 3) (a 3))");
 }
 
@@ -2405,8 +2405,8 @@ fn test_cse_breakage_example_lift_outside_bindings() {
         program.clone(),
         "(())".to_string(),
     ])
-        .trim()
-        .to_string();
+    .trim()
+    .to_string();
     assert_eq!(run_result_11, "1");
 }
 


### PR DESCRIPTION
Because this would have kept programs from compiling, this does not need to be feature gated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler optimization semantics for assign/CSE interaction; incorrect ceiling logic could skip valid CSE or still miscompile, though new tests lock in the reported breakage case.
> 
> **Overview**
> Fixes **common subexpression elimination (CSE)** incorrectly **hoisting** shared code above **`assign` / let bindings** when one occurrence lives in a binding that depends on other names in that form (e.g. `B` uses `A` while `(+ A 1)` is also duplicated in the assign body).
> 
> **`detect_common_cse_root`** now takes an optional **ceiling** path and returns **`Option`**: it refuses a root above a containing assign body that still provides names the subexpression needs, or when the only common root would sit above that ceiling. **`cse_optimize_bodyform`** computes that ceiling via new **`match_bindings`** (names in the duplicated expr ∩ names bound by enclosing lets) and **skips** the CSE rewrite when no safe root exists.
> 
> Adds regression coverage: unit test for ceiling rejection, **`cse-complex-2.clsp`**, and **`test_cse_breakage_example_lift_outside_bindings`** (compile + run expects **`1`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cfd027b276be3a489b09f289535664dcf08c94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->