### PR TITLE
Fix CSE dominance for conditional uses

### DIFF
--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -389,9 +389,7 @@ fn cse_is_unconditionally_used(
         })
 }
 
-// True if evaluating a condition always evaluates this CSE.  A use in the
-// condition expression is enough only when it is unconditional within that
-// expression; otherwise both branches must unconditionally use the CSE.
+// True if both branches of a condition always evaluate this CSE.
 fn cse_is_covering(
     condition: &CSECondition,
     conditions: &[CSECondition],
@@ -399,11 +397,6 @@ fn cse_is_covering(
 ) -> bool {
     if !condition.canonical {
         return false;
-    }
-
-    let condition_path = condition_subpath(&condition.path, 1);
-    if cse_is_unconditionally_used(&condition_path, conditions, instances) {
-        return true;
     }
 
     let consequent_path = condition_subpath(&condition.path, 2);

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -433,13 +433,9 @@ fn condition_scoped_common_root(
 ) -> Option<Vec<BodyformPathArc>> {
     conditions
         .iter()
-        .flat_map(|condition| {
-            [1, 2, 3]
-                .iter()
-                .map(|argument| condition_subpath(&condition.path, *argument))
-        })
-        .filter(|condition_child| path_overlap_one_way(condition_child, common_root))
-        .max_by_key(|condition_child| condition_child.len())
+        .map(|condition| condition_subpath(&condition.path, 1))
+        .filter(|condition_path| path_overlap_one_way(condition_path, common_root))
+        .max_by_key(|condition_path| condition_path.len())
 }
 
 pub fn cse_classify_by_conditions(

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -1,5 +1,4 @@
 use std::borrow::Borrow;
-use std::cmp::min;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::{Debug, Error, Formatter};
 use std::rc::Rc;
@@ -347,21 +346,71 @@ pub fn detect_conditions(bf: &BodyForm) -> Result<Vec<CSECondition>, CompileErr>
     Ok(results)
 }
 
-// True if for some condition path c_path there are matching instance paths
-// for either c_path + [CallArgument(1)] or both
-// c_path + [CallArgument(2)] and c_path + [CallArgument(3)]
-fn cse_is_covering(c_path: &[BodyformPathArc], instances: &[CSEInstance]) -> bool {
-    let mut target_paths = [c_path.to_vec(), c_path.to_vec(), c_path.to_vec()];
-    target_paths[0].push(BodyformPathArc::CallArgument(1));
-    target_paths[1].push(BodyformPathArc::CallArgument(2));
-    target_paths[2].push(BodyformPathArc::CallArgument(3));
+fn condition_subpath(c_path: &[BodyformPathArc], argument: usize) -> Vec<BodyformPathArc> {
+    let mut path = c_path.to_vec();
+    path.push(BodyformPathArc::CallArgument(argument));
+    path
+}
 
-    let have_targets: Vec<bool> = target_paths
+fn path_is_in_condition_branch(c_path: &[BodyformPathArc], path: &[BodyformPathArc]) -> bool {
+    let consequent_path = condition_subpath(c_path, 2);
+    let alternative_path = condition_subpath(c_path, 3);
+
+    path_overlap_one_way(&consequent_path, path) || path_overlap_one_way(&alternative_path, path)
+}
+
+fn first_branch_condition_between<'a>(
+    root: &[BodyformPathArc],
+    path: &[BodyformPathArc],
+    conditions: &'a [CSECondition],
+) -> Option<&'a CSECondition> {
+    conditions
         .iter()
-        .map(|t| instances.iter().any(|i| path_overlap_one_way(t, &i.path)))
-        .collect();
+        .filter(|c| path_overlap_one_way(root, &c.path))
+        .filter(|c| path_overlap_one_way(&c.path, path))
+        .filter(|c| path_is_in_condition_branch(&c.path, path))
+        .min_by_key(|c| c.path.len())
+}
 
-    have_targets[0] || (have_targets[1] && have_targets[2])
+fn cse_is_unconditionally_used(
+    root: &[BodyformPathArc],
+    conditions: &[CSECondition],
+    instances: &[CSEInstance],
+) -> bool {
+    instances
+        .iter()
+        .filter(|i| path_overlap_one_way(root, &i.path))
+        .any(|i| {
+            if let Some(condition) = first_branch_condition_between(root, &i.path, conditions) {
+                cse_is_covering(condition, conditions, instances)
+            } else {
+                true
+            }
+        })
+}
+
+// True if evaluating a condition always evaluates this CSE.  A use in the
+// condition expression is enough only when it is unconditional within that
+// expression; otherwise both branches must unconditionally use the CSE.
+fn cse_is_covering(
+    condition: &CSECondition,
+    conditions: &[CSECondition],
+    instances: &[CSEInstance],
+) -> bool {
+    if !condition.canonical {
+        return false;
+    }
+
+    let condition_path = condition_subpath(&condition.path, 1);
+    if cse_is_unconditionally_used(&condition_path, conditions, instances) {
+        return true;
+    }
+
+    let consequent_path = condition_subpath(&condition.path, 2);
+    let alternative_path = condition_subpath(&condition.path, 3);
+
+    cse_is_unconditionally_used(&consequent_path, conditions, instances)
+        && cse_is_unconditionally_used(&alternative_path, conditions, instances)
 }
 
 pub fn cse_classify_by_conditions(
@@ -376,25 +425,19 @@ pub fn cse_classify_by_conditions(
                 return None;
             }
 
-            let mut path_limit = 0;
-            let possible_root = d.instances[0].path.clone();
-            for i in d.instances.iter().skip(1) {
-                path_limit = min(path_limit, i.path.len());
-                for (idx, item) in possible_root.iter().take(path_limit).enumerate() {
-                    if &i.path[idx] != item {
-                        path_limit = idx;
-                        break;
-                    }
-                }
-            }
+            let possible_root = detect_common_cse_root(None, &d.instances)?;
 
-            // path_limit points to the common root of all instances of this
-            // cse detection.
-            //
-            // now find conditions that are downstream of the cse root.
+            // Find conditions that are downstream of the CSE root and contain
+            // at least one CSE instance.  These are the conditionals we would
+            // lift the CSE across.
             let applicable_conditions: Vec<CSECondition> = conditions
                 .iter()
-                .filter(|c| path_overlap_one_way(&c.path, &possible_root))
+                .filter(|c| path_overlap_one_way(&possible_root, &c.path))
+                .filter(|c| {
+                    d.instances
+                        .iter()
+                        .any(|i| path_overlap_one_way(&c.path, &i.path))
+                })
                 .cloned()
                 .collect();
 
@@ -403,7 +446,7 @@ pub fn cse_classify_by_conditions(
             // it encloses.
             let fully_canonical = applicable_conditions
                 .iter()
-                .all(|c| c.canonical && cse_is_covering(&c.path, &d.instances));
+                .all(|c| cse_is_covering(c, conditions, &d.instances));
 
             Some(CSEDetection {
                 hash: d.hash.clone(),

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -399,11 +399,47 @@ fn cse_is_covering(
         return false;
     }
 
+    let condition_path = condition_subpath(&condition.path, 1);
+    if cse_is_unconditionally_used(&condition_path, conditions, instances) {
+        return true;
+    }
+
     let consequent_path = condition_subpath(&condition.path, 2);
     let alternative_path = condition_subpath(&condition.path, 3);
 
     cse_is_unconditionally_used(&consequent_path, conditions, instances)
         && cse_is_unconditionally_used(&alternative_path, conditions, instances)
+}
+
+fn common_instance_path_prefix(instances: &[CSEInstance]) -> Vec<BodyformPathArc> {
+    let min_size = instances.iter().map(|i| i.path.len()).min().unwrap_or(0);
+    let mut last_match = min_size;
+
+    for idx in 0..min_size {
+        for instance in instances.iter() {
+            if instance.path[idx] != instances[0].path[idx] {
+                last_match = last_match.min(idx);
+                break;
+            }
+        }
+    }
+
+    instances[0].path.iter().take(last_match).cloned().collect()
+}
+
+fn condition_scoped_common_root(
+    conditions: &[CSECondition],
+    common_root: &[BodyformPathArc],
+) -> Option<Vec<BodyformPathArc>> {
+    conditions
+        .iter()
+        .flat_map(|condition| {
+            [1, 2, 3]
+                .iter()
+                .map(|argument| condition_subpath(&condition.path, *argument))
+        })
+        .filter(|condition_child| path_overlap_one_way(condition_child, common_root))
+        .max_by_key(|condition_child| condition_child.len())
 }
 
 pub fn cse_classify_by_conditions(
@@ -418,7 +454,9 @@ pub fn cse_classify_by_conditions(
                 return None;
             }
 
-            let possible_root = detect_common_cse_root(None, &d.instances)?;
+            let common_root = common_instance_path_prefix(&d.instances);
+            let possible_root = condition_scoped_common_root(conditions, &common_root)
+                .unwrap_or_else(|| detect_common_cse_root(None, &d.instances).unwrap_or_default());
 
             // Find conditions that are downstream of the CSE root and contain
             // at least one CSE instance.  These are the conditionals we would
@@ -791,11 +829,15 @@ pub fn cse_optimize_bodyform(
 
             // Detect the root of the CSE as the innermost expression that covers
             // all uses.
-            let replace_path = match detect_common_cse_root(ceiling.as_ref(), &d.instances) {
-                Some(rp) => rp,
-                None => {
-                    // Can't do anything with this if there was no common root.
-                    continue;
+            let replace_path = if ceiling.is_none() {
+                d.root.clone()
+            } else {
+                match detect_common_cse_root(ceiling.as_ref(), &d.instances) {
+                    Some(rp) => rp,
+                    None => {
+                        // Can't do anything with this if there was no common root.
+                        continue;
+                    }
                 }
             };
 

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -2411,6 +2411,17 @@ fn test_cse_breakage_example_lift_outside_bindings() {
 }
 
 #[test]
+fn test_cse_breakage_example_conditional_dominance_trick() {
+    let filename = "resources/tests/cse-complex-4.clsp";
+    let program = do_basic_run(&vec!["run".to_string(), filename.to_string()])
+        .trim()
+        .to_string();
+
+    eprintln!(">> {program}");
+    assert!(program.starts_with("("));
+}
+
+#[test]
 fn test_cse_breakage_example_letstar() {
     let filename = "resources/tests/cse-bad-letstar.clsp";
     let program = do_basic_run(&vec!["run".to_string(), filename.to_string()])

--- a/src/tests/compiler/optimizer/cse.rs
+++ b/src/tests/compiler/optimizer/cse.rs
@@ -16,7 +16,9 @@ use crate::compiler::compiler::{compile_from_compileform, DefaultCompilerOpts};
 use crate::compiler::comptypes::{BodyForm, CompileForm, CompilerOpts, DefunData, HelperForm};
 use crate::compiler::dialect::AcceptedDialect;
 use crate::compiler::frontend::compile_bodyform;
-use crate::compiler::optimize::cse::cse_optimize_bodyform;
+use crate::compiler::optimize::cse::{
+    cse_classify_by_conditions, cse_detect, cse_optimize_bodyform, detect_conditions, CSEDetection,
+};
 use crate::compiler::optimize::get_optimizer;
 use crate::compiler::sexp::{enlist, parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
@@ -44,6 +46,77 @@ fn smoke_test_cse_optimization() {
     let re_def = r"(let ((cse_[$]_[0-9]+ ([*] ([+] 1 Q) R))) (a (i Q (com (G (- Q 1) cse_[$]_[0-9]+)) (com cse_[$]_[0-9]+)) 1))".replace("(", r"\(").replace(")",r"\)");
     let re = Regex::new(&re_def).expect("should become a regex");
     assert!(re.is_match(&cse_transformed.to_sexp().to_string()));
+}
+
+fn classify_cse_detections(source: &str) -> Vec<CSEDetection> {
+    let srcloc = Srcloc::start("*conditional-cse-test*");
+    let opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new("*conditional-cse-test*"));
+    let parsed = parse_sexp(srcloc, source.bytes()).expect("should parse");
+    let bodyform = compile_bodyform(opts, parsed[0].clone()).expect("should compile");
+    let conditions = detect_conditions(&bodyform).expect("should detect conditions");
+    let cse_raw_detections = cse_detect(&bodyform).expect("should detect CSE");
+
+    cse_classify_by_conditions(&conditions, &cse_raw_detections)
+}
+
+fn cse_saturated_for(source: &str, subexp: &str) -> bool {
+    let matching_detections: Vec<CSEDetection> = classify_cse_detections(source)
+        .into_iter()
+        .filter(|d| d.subexp.to_sexp().to_string() == subexp)
+        .collect();
+
+    assert_eq!(
+        matching_detections.len(),
+        1,
+        "expected one detection for {subexp}"
+    );
+
+    matching_detections[0].saturated
+}
+
+#[test]
+fn test_cse_conditional_condition_use_does_not_cover_condition() {
+    let source = indoc! {"
+    (a
+      (i
+        (a (i B (com (+ X 1)) (com 0)) @)
+        (com 1)
+        (com (+ X 1))
+      )
+      @
+    )"};
+
+    assert!(!cse_saturated_for(source, "(+ X 1)"));
+}
+
+#[test]
+fn test_cse_conditional_branch_use_does_not_cover_condition() {
+    let source = indoc! {"
+    (a
+      (i
+        A
+        (com (a (i B (com (+ X 1)) (com 0)) @))
+        (com (+ X 1))
+      )
+      @
+    )"};
+
+    assert!(!cse_saturated_for(source, "(+ X 1)"));
+}
+
+#[test]
+fn test_cse_fully_covered_nested_condition_covers_branch() {
+    let source = indoc! {"
+    (a
+      (i
+        A
+        (com (a (i B (com (+ X 1)) (com (+ X 1))) @))
+        (com (+ X 1))
+      )
+      @
+    )"};
+
+    assert!(cse_saturated_for(source, "(+ X 1)"));
 }
 
 #[test]

--- a/src/tests/compiler/optimizer/cse.rs
+++ b/src/tests/compiler/optimizer/cse.rs
@@ -75,7 +75,7 @@ fn cse_saturated_for(source: &str, subexp: &str) -> bool {
 }
 
 #[test]
-fn test_cse_condition_use_does_not_cover_condition() {
+fn test_cse_unconditional_condition_use_covers_condition() {
     let source = indoc! {"
     (a
       (i
@@ -86,7 +86,7 @@ fn test_cse_condition_use_does_not_cover_condition() {
       @
     )"};
 
-    assert!(!cse_saturated_for(source, "(+ X 1)"));
+    assert!(cse_saturated_for(source, "(+ X 1)"));
 }
 
 #[test]

--- a/src/tests/compiler/optimizer/cse.rs
+++ b/src/tests/compiler/optimizer/cse.rs
@@ -75,6 +75,21 @@ fn cse_saturated_for(source: &str, subexp: &str) -> bool {
 }
 
 #[test]
+fn test_cse_condition_use_does_not_cover_condition() {
+    let source = indoc! {"
+    (a
+      (i
+        (+ X 1)
+        (com 1)
+        (com (+ X 1))
+      )
+      @
+    )"};
+
+    assert!(!cse_saturated_for(source, "(+ X 1)"));
+}
+
+#[test]
 fn test_cse_conditional_condition_use_does_not_cover_condition() {
     let source = indoc! {"
     (a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make CSE dominance account for conditionally evaluated nested branches/conditions
- keep CSE bindings for shared condition-expression subexpressions scoped inside that condition expression instead of lifting to the function root
- add optimizer regressions for conditional condition/branch uses and a `cse-complex-4.clsp` compile regression

## Testing
- `cargo test test_cse_unconditional_condition_use_covers_condition --lib -- --nocapture`
- `cargo test test_cse_conditional --lib -- --nocapture`
- `cargo test test_cse_fully_covered_nested_condition_covers_branch --lib -- --nocapture`
- `cargo test test_cse_breakage_example_conditional_dominance_trick --lib -- --nocapture`
- `cargo test cse --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-336728f4-8a57-4079-a308-8d2c4eddf53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-336728f4-8a57-4079-a308-8d2c4eddf53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

