### PR TITLE
Protect variables in inner scopes.

### DIFF
--- a/resources/tests/cse-complex-2.clsp
+++ b/resources/tests/cse-complex-2.clsp
@@ -1,0 +1,14 @@
+(mod (X)
+  (include *standard-cl-26*)
+
+  (defun F (X)
+    (strlen
+      (assign
+        A (+ X 1)
+        B (+ A 1)
+        (+ A 1)
+        )
+      )
+    )
+  (F X)
+  )

--- a/src/compiler/optimize/cse.rs
+++ b/src/compiler/optimize/cse.rs
@@ -437,15 +437,22 @@ fn detect_common_cse_root(instances: &[CSEInstance]) -> Vec<BodyformPathArc> {
         }
     }
 
-    // Back it up to the body of a let binding.
+    // Back it up to the body of a let binding or where we've removed a variable from
+    // its own scope, which can be true if an assign form is not in a body position.
     for (idx, f) in target_path.iter().enumerate().rev() {
         if f == &BodyformPathArc::BodyOf {
-            return target_path.iter().take(idx + 1).cloned().collect();
+            return Some(target_path.iter().take(idx + 1).cloned().collect());
+        }
+
+        if let Some(ceiling) = ceiling {
+            if ceiling.len() > idx || (ceiling.len() == idx && target_path[0..idx] != *ceiling) {
+                return None;
+            }
         }
     }
 
     // No internal root if there was no let traversal.
-    Vec::new()
+    Some(Vec::new())
 }
 
 // Finds lambdas that contain CSE detection instances from the provided list.
@@ -587,6 +594,31 @@ fn merge_cse_binding(body: &BodyForm, binding: Rc<Binding>) -> BodyForm {
     body.clone()
 }
 
+fn match_bindings(bindings: &[Rc<Binding>], used_names: &HashSet<Vec<u8>>) -> HashSet<Vec<u8>> {
+    let mut new_set = HashSet::new();
+    for b in bindings.iter() {
+        match &b.pattern {
+            BindingPattern::Name(n) => {
+                let n_ref: &[u8] = n;
+                if used_names.contains(n_ref) {
+                    new_set.insert(n.clone());
+                }
+            }
+            BindingPattern::Complex(p) => {
+                let names: HashSet<Vec<u8>> =
+                    collect_used_names_sexp(p.clone()).into_iter().collect();
+                for n in names.iter() {
+                    let n_ref: &[u8] = n;
+                    if used_names.contains(n_ref) {
+                        new_set.insert(n.clone());
+                    }
+                }
+            }
+        }
+    }
+    new_set
+}
+
 type CSEReplacementTargetAndBindings<'a> = Vec<&'a (Vec<BodyformPathArc>, Vec<BindingStackEntry>)>;
 
 /// Given a bodyform, CSE analyze and produce a semantically equivalent bodyform
@@ -670,6 +702,34 @@ pub fn cse_optimize_bodyform(
                 ));
             };
 
+            let used_names: HashSet<Vec<u8>> = collect_used_names_bodyform(&prototype_instance)
+                .into_iter()
+                .collect();
+            // Detect the ceiling for this cse move.  It can only go to the body of a
+            // containing assignment form that binds a name it needs.
+            //
+            // This fixes a bug.  The requirements for causing the bug now are that one use
+            // of the common subexpression is in a binding that uses other bound values.
+            let mut ceiling = None;
+            for instance in d.instances.iter() {
+                for (idx, _f) in instance.path.iter().enumerate().rev() {
+                    let want_path: Vec<BodyformPathArc> =
+                        instance.path.iter().take(idx).cloned().collect();
+                    if let Some(BodyForm::Let(_, data)) =
+                        retrieve_bodyform(&want_path, &function_body, &|b: &BodyForm| b.clone())
+                    {
+                        let names_provided_by_let_in_cse =
+                            match_bindings(&data.bindings, &used_names);
+                        if !names_provided_by_let_in_cse.is_empty() {
+                            let mut top_possible_body = want_path;
+                            top_possible_body.push(BodyformPathArc::BodyOf);
+                            ceiling = Some(top_possible_body);
+                            break;
+                        }
+                    }
+                }
+            }
+
             // We'll assign a fresh variable for each of the detections
             // that are applicable now.
             let new_variable_name = gensym(b"cse".to_vec());
@@ -692,7 +752,13 @@ pub fn cse_optimize_bodyform(
 
             // Detect the root of the CSE as the innermost expression that covers
             // all uses.
-            let replace_path = detect_common_cse_root(&d.instances);
+            let replace_path = match detect_common_cse_root(ceiling.as_ref(), &d.instances) {
+                Some(rp) => rp,
+                None => {
+                    // Can't do anything with this if there was no common root.
+                    continue;
+                }
+            };
 
             // Route the captured repeated subexpression into intervening lambdas.
             // This means that the lambdas will gain a capture on the left side of

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -2391,6 +2391,26 @@ fn test_cse_breakage_example() {
 }
 
 #[test]
+fn test_cse_breakage_example_lift_outside_bindings() {
+    let filename = "resources/tests/cse-complex-2.clsp";
+    let program = do_basic_run(&vec!["run".to_string(), filename.to_string()])
+        .trim()
+        .to_string();
+
+    eprintln!(">> {program}");
+    assert!(program.starts_with("("));
+
+    let run_result_11 = do_basic_brun(&vec![
+        "brun".to_string(),
+        program.clone(),
+        "(())".to_string(),
+    ])
+    .trim()
+    .to_string();
+    assert_eq!(run_result_11, "1");
+}
+
+#[test]
 fn test_cse_breakage_example_letstar() {
     let filename = "resources/tests/cse-bad-letstar.clsp";
     let program = do_basic_run(&vec!["run".to_string(), filename.to_string()])


### PR DESCRIPTION
  This would have prevented compilation so it doesn't need to be feature gated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes common-subexpression elimination placement logic in the optimizer, which can subtly affect generated programs and correctness when `assign`/`let` bindings are involved.
> 
> **Overview**
> Fixes a CSE optimizer bug where a common subexpression could be lifted outside the scope of variables it depends on (notably when one occurrence is inside an `assign` binding expression).
> 
> The CSE pass now computes a *ceiling* based on which binding names the subexpression uses, restricts `detect_common_cse_root` accordingly (skipping the optimization when no safe common root exists), and adds a regression test program (`cse-complex-2.clsp`) plus a new classic test that compiles and executes it to ensure the result remains correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dfac3c4d2723d4b20967d38bdf116af4054c172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->