### PR TITLE
Fix this quarter's new clippy issue

### DIFF
--- a/src/classic/clvm/serialize.rs
+++ b/src/classic/clvm/serialize.rs
@@ -155,10 +155,7 @@ impl OpStackEntry for OpCons {
         _f: &mut Stream,
         to_sexp_f: Box<dyn TToSexpF<'a>>,
     ) -> Option<EvalErr> {
-        match val_stack
-            .pop()
-            .and_then(|r| val_stack.pop().map(|l| (l, r)))
-        {
+        match val_stack.pop().zip(val_stack.pop()) {
             None => None,
             Some((l, r)) => {
                 match to_sexp_f.invoke(allocator, CastableType::TupleOf(Rc::new(l), Rc::new(r))) {

--- a/src/classic/clvm/serialize.rs
+++ b/src/classic/clvm/serialize.rs
@@ -155,7 +155,8 @@ impl OpStackEntry for OpCons {
         _f: &mut Stream,
         to_sexp_f: Box<dyn TToSexpF<'a>>,
     ) -> Option<EvalErr> {
-        match val_stack.pop().zip(val_stack.pop()) {
+        let item_b = val_stack.pop();
+        match val_stack.pop().zip(item_b) {
             None => None,
             Some((l, r)) => {
                 match to_sexp_f.invoke(allocator, CastableType::TupleOf(Rc::new(l), Rc::new(r))) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical lint-driven refactor with equivalent control flow; no functional or security impact expected.
> 
> **Overview**
> Updates **`OpCons::invoke`** in `serialize.rs` to satisfy a new Clippy lint by replacing nested `pop().and_then(...)` with popping the right item first, then matching on `val_stack.pop().zip(item_b)`.
> 
> Behavior is unchanged: build a cons from two stack values when both pops succeed, otherwise return `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb2e99da1aed756eabc45abb0d0cf788eca83492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->