### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/check-commit-signing.yml
+++ b/.github/workflows/check-commit-signing.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
 
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v5.0.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only version tag change on checkout with no application or security logic changes.
> 
> **Overview**
> Updates **managed** GitHub Actions workflows to use `actions/checkout@v6` instead of the pinned patch release `actions/checkout@v6.0.2`.
> 
> Affected workflows: **check-commit-signing** and **dependency-review**. Checkout step options (e.g. `fetch-depth`) are unchanged; only the action version reference moves to the major `v6` tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deee501b0e529a52b8c22fd7345094b0014a6054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->