### PR TITLE
Version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.9",
 ]
@@ -735,15 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "p256"
@@ -915,19 +906,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.25.1",
+ "pyo3-build-config 0.29.0",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
@@ -942,29 +930,28 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
- "pyo3-build-config 0.25.1",
+ "pyo3-build-config 0.29.0",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2 1.0.95",
  "pyo3-macros-backend",
@@ -974,13 +961,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2 1.0.95",
- "pyo3-build-config 0.25.1",
  "quote 1.0.40",
  "syn 2.0.104",
 ]
@@ -1293,9 +1279,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -1379,12 +1365,6 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unindent"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "chialisp"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "binascii",
  "chia-bls 0.42.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chialisp"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 authors = ["Art Yerkes <art.yerkes@gmail.com>"]
 description = "tools for working with chialisp language; compiler, repl, python and wasm bindings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lfsr = { version = "0.3.0", optional = true }
 num = "0.4.3"
 num-bigint = { version = "0.4.4", features = ["serde"] }
 num-traits = "0.2.15"
-rand = { version = "0.9.4", optional = true }
+rand = { version = "0.9.4", optional = true, features = ["std", "std_rng", "os_rng"] }
 rand_chacha = { version = "0.9.0", optional = true }
 regex = "1.12.3"
 serde = { version = "1.0", features = ["derive", "rc"] }
@@ -41,7 +41,7 @@ yaml-rust2 = "0.11.0"
 subprocess = { version = "1.1.0", optional = true }
 
 [dependencies.pyo3]
-version = "0.25.1"
+version = "0.29.0"
 features = ["abi3-py310", "extension-module"]
 optional = true
 

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -2,9 +2,9 @@
 // #[allow(clippy::borrow_deref_ref)]
 // Eventually this can be downgraded and applied just to compile_clvm
 // re: https://github.com/rust-lang/rust-clippy/issues/8971
-use pyo3::CastError;
 use pyo3::exceptions::PyException;
 use pyo3::types::{PyBool, PyDict, PyString, PyTuple};
+use pyo3::CastError;
 use pyo3::{create_exception, prelude::*, IntoPyObjectExt};
 
 use std::cmp::Ordering;

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -2,6 +2,7 @@
 // #[allow(clippy::borrow_deref_ref)]
 // Eventually this can be downgraded and applied just to compile_clvm
 // re: https://github.com/rust-lang/rust-clippy/issues/8971
+use pyo3::CastError;
 use pyo3::exceptions::PyException;
 use pyo3::types::{PyBool, PyDict, PyString, PyTuple};
 use pyo3::{create_exception, prelude::*, IntoPyObjectExt};
@@ -79,7 +80,7 @@ fn get_source_from_input(input_code: CompileClvmSource) -> PyResult<(String, Str
                     .and_then(|x| x.get_item(0))
                     .and_then(|x| x.str())
             } else {
-                input_path.extract()
+                input_path.extract().map_err(|e: CastError| e.into())
             }?;
 
             let mut path_string = real_input_path.to_string();
@@ -101,7 +102,7 @@ fn run_clvm_compilation(
     action: CompileClvmAction,
     search_paths: Vec<String>,
     export_symbols: Option<bool>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     // Resolve the input, get the indicated path and content.
     let (path_string, file_content) = get_source_from_input(input_code)?;
 
@@ -148,7 +149,7 @@ fn run_clvm_compilation(
 
             // Produce compiled output according to whether output with symbols
             // or just the standard result is required.
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 if export_symbols == Some(true) {
                     let mut result_dict = HashMap::new();
                     result_dict.insert("output".to_string(), compiled.into_py_any(py)?);
@@ -167,7 +168,7 @@ fn run_clvm_compilation(
                     .map(|rlist| rlist.iter().map(|i| decode_string(&i.name)).collect())?;
 
             // Return all visited files.
-            Python::with_gil(|py| result_deps.into_py_any(py))
+            Python::attach(|py| result_deps.into_py_any(py))
         }
     }
 }
@@ -179,7 +180,7 @@ fn compile_clvm(
     output_path: String,
     search_paths: Vec<String>,
     export_symbols: Option<bool>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     run_clvm_compilation(
         CompileClvmSource::SourcePath(input_path),
         CompileClvmAction::CompileCode(Some(output_path)),
@@ -194,7 +195,7 @@ fn compile(
     source: String,
     search_paths: Vec<String>,
     export_symbols: Option<bool>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     run_clvm_compilation(
         CompileClvmSource::SourceCode("*inline*".to_string(), source),
         CompileClvmAction::CompileCode(None),
@@ -208,7 +209,7 @@ fn compile(
 fn check_dependencies(
     input_path: Bound<'_, PyAny>,
     search_paths: Vec<String>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     run_clvm_compilation(
         CompileClvmSource::SourcePath(input_path),
         CompileClvmAction::CheckDependencies,
@@ -225,7 +226,7 @@ struct PythonRunStep {
     rx: Receiver<(bool, Option<BTreeMap<String, String>>)>,
 }
 
-fn runstep(myself: &mut PythonRunStep) -> PyResult<Option<PyObject>> {
+fn runstep(myself: &mut PythonRunStep) -> PyResult<Option<Py<PyAny>>> {
     if myself.ended {
         return Ok(None);
     }
@@ -249,7 +250,7 @@ fn runstep(myself: &mut PythonRunStep) -> PyResult<Option<PyObject>> {
     let dict_result = res
         .1
         .map(|m| {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let dict = PyDict::new(py);
                 for (k, v) in m.iter() {
                     let _ = dict.set_item(PyString::new(py, k), PyString::new(py, v));
@@ -272,8 +273,8 @@ impl PythonRunStep {
         let _ = self.tx.send(true);
     }
 
-    fn step(&mut self, py: Python) -> PyResult<Option<PyObject>> {
-        py.allow_threads(|| runstep(self))
+    fn step(&mut self, py: Python) -> PyResult<Option<Py<PyAny>>> {
+        py.detach(|| runstep(self))
     }
 }
 
@@ -289,7 +290,7 @@ impl CldbSinglePythonOverride {
 
 impl CldbSingleBespokeOverride for CldbSinglePythonOverride {
     fn get_override(&self, env: Rc<SExp>) -> Result<Rc<SExp>, RunFailure> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let arg_value = clvm_value_to_python(py, env.clone())
                 .map_err(|e| RunFailure::RunErr(env.loc(), format!("{}", e)))?;
             let res = self
@@ -317,7 +318,7 @@ fn start_clvm_program(
     let (command_tx, command_rx) = mpsc::channel();
     let (result_tx, result_rx) = mpsc::channel();
 
-    let print_only_value = Python::with_gil(|py| {
+    let print_only_value = Python::attach(|py| {
         let print_only_option = run_options
             .and_then(|h| h.get("print").map(|p| Ok(p.clone_ref(py))))
             .or_else(|| Some(PyBool::new(py, false).into_py_any(py)))
@@ -361,7 +362,7 @@ fn start_clvm_program(
             HashMap::new();
         if let Some(t) = overrides {
             for (k, v) in t.iter() {
-                let v_clone = Python::with_gil(|py| v.clone_ref(py));
+                let v_clone = Python::attach(|py| v.clone_ref(py));
                 let override_fun_callable = CldbSinglePythonOverride::new(v_clone);
                 overrides_table.insert(k.clone(), Box::new(override_fun_callable));
             }

--- a/src/py/binutils.rs
+++ b/src/py/binutils.rs
@@ -17,9 +17,9 @@ fn convert_to_external<'a>(
     cons: Bound<'a, PyAny>,
     from_bytes: Bound<'a, PyAny>,
     root_node: NodePtr,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let mut stack: Vec<NodePtr> = vec![root_node];
-    let mut finished = HashMap::<NodePtr, PyObject>::new();
+    let mut finished = HashMap::<NodePtr, Py<PyAny>>::new();
 
     while let Some(node) = stack.last() {
         let node = *node; // To avoid borrowing issues with the stack
@@ -31,11 +31,10 @@ fn convert_to_external<'a>(
                 if left_finished && right_finished {
                     stack.pop();
 
-                    let result: PyObject = Python::with_gil(|py| {
+                    let result: Py<PyAny> = Python::attach(|py| {
                         let a = finished.get(&left).unwrap();
                         let b = finished.get(&right).unwrap();
-                        let args = PyTuple::new(py, &[a, b])?;
-                        cons.call1(args).and_then(|value| value.into_py_any(py))
+                        cons.call1((a, b)).and_then(|value| value.into_py_any(py))
                     })?
                     .into();
 
@@ -53,15 +52,14 @@ fn convert_to_external<'a>(
                 stack.pop();
 
                 if !finished.contains_key(&node) {
-                    let converted: PyObject = Python::with_gil(|py| {
+                    let converted: Py<PyAny> = Python::attach(|py| {
                         let atom = allocator.atom(node);
                         let bytes = PyBytes::new(py, atom.as_ref());
                         let args = PyTuple::new(py, &[bytes])?;
                         from_bytes
                             .call1(args)
                             .and_then(|value| value.into_py_any(py))
-                    })?
-                    .into();
+                    })?;
                     finished.insert(node, converted);
                 }
             }
@@ -80,7 +78,7 @@ pub fn assemble_generic(
     cons: Bound<'_, PyAny>,
     from_bytes: Bound<'_, PyAny>,
     args: String,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let mut allocator = Allocator::new();
     let assembled =
         binutils::assemble(&mut allocator, &args).map_err(|e| ConvError::new_err(e.to_string()))?;

--- a/src/py/pyval.rs
+++ b/src/py/pyval.rs
@@ -18,7 +18,7 @@ pub fn map_err_to_pyerr<PA>(srcloc: Srcloc, r: PyResult<PA>) -> Result<PA, RunFa
 
 pub fn python_value_to_clvm(val: Bound<'_, PyAny>) -> Result<Rc<SExp>, RunFailure> {
     let srcloc = Srcloc::start("*python*");
-    val.downcast::<PyList>()
+    val.cast::<PyList>()
         .ok()
         .map(|l| {
             if l.is_empty() {
@@ -39,7 +39,7 @@ pub fn python_value_to_clvm(val: Bound<'_, PyAny>) -> Result<Rc<SExp>, RunFailur
         })
         .map(Some)
         .unwrap_or_else(|| {
-            val.downcast::<PyTuple>()
+            val.cast::<PyTuple>()
                 .map(|t| {
                     if t.len() != 2 {
                         Err(RunFailure::RunErr(
@@ -60,7 +60,7 @@ pub fn python_value_to_clvm(val: Bound<'_, PyAny>) -> Result<Rc<SExp>, RunFailur
         })
         .map(Some)
         .unwrap_or_else(|| {
-            val.downcast::<PyBytes>()
+            val.cast::<PyBytes>()
                 .map(|b| Ok(Rc::new(SExp::Atom(srcloc.clone(), b.as_bytes().to_vec()))))
                 .ok()
         })

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.9",
 ]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -69,6 +69,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,7 +119,7 @@ dependencies = [
  "hex",
  "hkdf",
  "linked-hash-map",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
 ]
 
@@ -126,7 +135,7 @@ dependencies = [
  "hex",
  "hkdf",
  "linked-hash-map",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
 ]
 
@@ -136,7 +145,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f03c71bc63599a711caad15dafca1d2a948c26b4c8a021709a338149632769"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -145,7 +154,7 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6636ca8bba852fc516eacf01b2c3964b6b290359e7d1e89b950e6754e2a1082"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -196,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "chialisp"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "binascii",
  "chia-bls 0.42.0",
@@ -215,7 +224,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "unicode-segmentation",
  "wasm-bindgen",
@@ -224,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_tools_wasm"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "chialisp",
  "clvmr",
@@ -266,10 +275,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -297,12 +321,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "der"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.4",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -313,10 +346,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -332,7 +376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -347,7 +391,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -522,7 +566,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -567,7 +620,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -577,7 +630,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.9",
 ]
 
 [[package]]
@@ -734,7 +787,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -977,8 +1030,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.9",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -988,8 +1041,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.9",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -998,7 +1062,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -1008,7 +1072,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
 ]
 
@@ -1121,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1133,9 +1197,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "version_check"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_wasm"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2018"
 authors = ["Art Yerkes <art.yerkes@gmail.com>"]
 description = "tools for working with chialisp language; compiler, repl, python and wasm bindings"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> PyO3 0.25→0.29 is a breaking FFI/API migration for the Python bindings; behavior should be equivalent but extension wheels need rebuild and regression testing.
> 
> **Overview**
> Releases **chialisp** and **clvm_tools_wasm** as **0.4.6**, with lockfile updates for **PyO3 0.29**, **sha2 0.11**, and related transitive crates.
> 
> The Python extension is updated for PyO3 0.29: `Python::with_gil` → `Python::attach`, `py.allow_threads` → `py.detach`, `downcast` → `cast`, public APIs now return `Py<PyAny>` instead of `PyObject`, and path extraction maps `CastError` explicitly. Optional `rand` now enables `std`, `std_rng`, and `os_rng`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458e456a1b100672ba621e80f15cdad21e965f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->