### PR TITLE
Re-create external pr 506 darkverbito:fix/deinline-module-phase-blowup

### DIFF
--- a/resources/tests/module/deinline_module_blowup.clsp
+++ b/resources/tests/module/deinline_module_blowup.clsp
@@ -1,0 +1,39 @@
+;; Regression: a multi-export module whose exports share a chain of helpers,
+;; each containing a deep nested `let` stack.  Every let binding becomes a
+;; `NoInlinePreference` synthetic helper, so the module-phase deinline size
+;; search iterates over a large synthetic-function set and re-runs full code
+;; generation for each one.  Before the fix this is superlinear and effectively
+;; hangs; after the fix (the search is skipped in module phase, where it is a
+;; guaranteed no-op) the module compiles quickly and correctly.
+;;
+;; Arithmetic is addition-only so the export results stay small and exactly
+;; assertable while the let-stack still produces the synthetic helpers that
+;; drive the search.
+(include *standard-cl-25*)
+
+(defun h0 (x)
+  (let ((a (+ (h1 x) 1)) (b (+ (h1 x) 2)))
+    (let ((c (+ a b)) (d (+ a 3)))
+      (let ((e (+ c d)) (f (+ c 4)))
+        (let ((g (+ e f)) (i (+ e 5)))
+          (+ g i))))))
+
+(defun h1 (x)
+  (let ((a (+ (h2 x) 1)) (b (+ (h2 x) 2)))
+    (let ((c (+ a b)) (d (+ a 3)))
+      (let ((e (+ c d)) (f (+ c 4)))
+        (let ((g (+ e f)) (i (+ e 5)))
+          (+ g i))))))
+
+(defun h2 (x)
+  (let ((a (+ x 1)) (b (+ x 2)))
+    (let ((c (+ a b)) (d (+ a 3)))
+      (let ((e (+ c d)) (f (+ c 4)))
+        (let ((g (+ e f)) (i (+ e 5)))
+          (+ g i))))))
+
+(defun entry_a (x) (h0 (+ x 1)))
+(defun entry_b (x) (h0 (+ x 2)))
+
+(export entry_a)
+(export entry_b)

--- a/src/compiler/optimize/deinline.rs
+++ b/src/compiler/optimize/deinline.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::compiler::codegen::codegen;
-use crate::compiler::optimize::depgraph::{DepgraphKind, DepgraphOptions, FunctionDependencyGraph};
+use crate::compiler::optimize::depgraph::{DepgraphKind, FunctionDependencyGraph};
 use crate::compiler::optimize::{sexp_scale, SyntheticType};
 use crate::compiler::{
     BasicCompileContext, CompileErr, CompileForm, CompilerOpts, Funcache, HelperForm,
@@ -61,16 +61,23 @@ pub fn deinline_opt(
     }
 
     let is_module_compile = opts.module_phase().is_some();
-    let depgraph = if is_module_compile {
-        FunctionDependencyGraph::new_with_options(
-            &compileform,
-            DepgraphOptions {
-                with_constants: true,
-            },
-        )
-    } else {
-        FunctionDependencyGraph::new(&compileform)
-    };
+
+    // In module phase the inline/deinline size search below is a guaranteed
+    // no-op, so skip it.  The `flip_helper` guard only permits the
+    // non-inline -> inline direction for `NoInlinePreference` synthetics when
+    // `is_module_compile` is true, and the module convention of keeping those
+    // synthetics non-inline means that direction is always strictly larger and
+    // therefore always rejected.  Running the search anyway still pays
+    // O(functions) full code generations per root set -- each itself superlinear
+    // in program size -- which dominates compile time on large multi-export
+    // modules to the point that compilation appears to hang.  Returning the
+    // unchanged program here is output-identical (the search never updates
+    // `best_compileform` in module phase) and removes the blow-up.
+    if is_module_compile {
+        return Ok(compileform);
+    }
+
+    let depgraph = FunctionDependencyGraph::new(&compileform);
 
     let mut best_compileform = compileform.clone();
     let generated_program = codegen(context, opts.clone(), Some(&depgraph), &best_compileform)?;

--- a/src/tests/compiler/modules.rs
+++ b/src/tests/compiler/modules.rs
@@ -838,3 +838,41 @@ fn test_module_constant_cycle_deadlock() {
         "expected a compile error for cyclic constants"
     );
 }
+
+// Regression test for a module-phase compile-time blow-up in deinline_opt.
+//
+// A multi-export module whose exports share a chain of helpers, each containing
+// a deep nested `let` stack, produces many `NoInlinePreference` synthetic
+// helpers.  The module-phase deinline size search iterated over that whole
+// synthetic-function set, re-running full code generation per function per pass.
+// In module phase the search can never keep a flip (its guard only explores the
+// strictly-larger non-inline -> inline direction for these synthetics), so it is
+// a guaranteed no-op, yet it still costs O(functions) superlinear code
+// generations and on larger modules makes compilation appear to hang.
+//
+// This test simply compiles such a module and runs both exports.  Before the fix
+// it does not finish in any reasonable time; after the fix it compiles quickly
+// and produces the expected results.
+#[test]
+fn test_module_phase_deinline_does_not_blow_up() {
+    let filename = "resources/tests/module/deinline_module_blowup.clsp";
+    let content = fs::read_to_string(filename).expect("file should exist");
+    let a_hex = "resources/tests/module/deinline_module_blowup_entry_a.hex";
+    let b_hex = "resources/tests/module/deinline_module_blowup_entry_b.hex";
+    test_compile_and_run_program_with_modules(
+        filename,
+        &content,
+        &[
+            HexArgumentOutcome {
+                hexfile: a_hex,
+                argument: "(10)",
+                outcome: Run("7530"),
+            },
+            HexArgumentOutcome {
+                hexfile: b_hex,
+                argument: "(7)",
+                outcome: Run("6506"),
+            },
+        ],
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches compiler optimization on the module compile path; behavior is intended to be identical but skips work that previously ran on every module with helpers.
> 
> **Overview**
> Fixes **module compilation hanging** on large multi-export modules with many nested-`let` synthetic helpers by **short-circuiting `deinline_opt` during module phase**.
> 
> In module phase the inline/deinline size search could never accept a flip for `NoInlinePreference` synthetics, so it was wasted work: repeated full code generation over a huge helper set. The optimizer now returns the compile form unchanged when `opts.module_phase()` is set, which is **output-identical** to running the search. The module-only dependency graph built with `with_constants: true` is removed because that path is no longer reached.
> 
> Adds regression coverage via `deinline_module_blowup.clsp` and `test_module_phase_deinline_does_not_blow_up`, asserting both exports compile and run with expected numeric results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60af5cce6f46bd1da057912d1417855ccddd0dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->