### PR TITLE
Assemble operator names on modern classic codegen path

### DIFF
--- a/src/classic/clvm_tools/stages/stage_2/operators.rs
+++ b/src/classic/clvm_tools/stages/stage_2/operators.rs
@@ -15,17 +15,21 @@ use clvm_rs::run_program::run_program_with_pre_eval;
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType, Stream};
 use crate::classic::clvm::OPERATORS_LATEST_VERSION;
 
-use crate::classic::clvm::keyword_from_atom;
 use crate::classic::clvm::sexp::proper_list;
+use crate::classic::clvm::{keyword_from_atom, keyword_to_atom};
 
-use crate::classic::clvm_tools::binutils::{assemble_from_ir, disassemble_to_ir_with_kw, disassemble};
+use crate::classic::clvm_tools::binutils::{
+    assemble_from_ir, disassemble, disassemble_to_ir_with_kw,
+};
 use crate::classic::clvm_tools::ir::reader::read_ir;
 use crate::classic::clvm_tools::ir::writer::write_ir_to_stream;
 use crate::classic::clvm_tools::sha256tree::TreeHash;
 use crate::classic::clvm_tools::stages::stage_0::{
     DefaultProgramRunner, OriginalDialect, RunProgramOption, TRunProgram,
 };
-use crate::classic::clvm_tools::stages::stage_2::abstraction::{ClError, ClassicAllocator};
+use crate::classic::clvm_tools::stages::stage_2::abstraction::{
+    ASExp, BufCarrier, ClError, ClassicAllocator,
+};
 use crate::classic::clvm_tools::stages::stage_2::compile::do_com_prog_for_dialect;
 use crate::classic::clvm_tools::stages::stage_2::optimize::do_optimize;
 
@@ -398,6 +402,61 @@ impl CompilerOperatorsInternal {
     }
 }
 
+fn assemble_operator_heads<A: ClassicAllocator>(
+    allocator: &mut A,
+    sexp: &A::NodePtr,
+    operator_position: bool,
+) -> Result<A::NodePtr, ClError>
+where
+    A::NodePtr: Clone,
+{
+    match allocator.sexp(sexp) {
+        ASExp::Pair(first, rest) => {
+            // A pair in the head of an argument list starts a nested expression.
+            let first_is_expression = matches!(allocator.sexp(&first), ASExp::Pair(_, _));
+            let first = assemble_operator_heads(
+                allocator,
+                &first,
+                operator_position || first_is_expression,
+            )?;
+            let rest = assemble_operator_heads(allocator, &rest, false)?;
+            allocator.new_pair(allocator.loc(sexp), &first, &rest)
+        }
+        ASExp::Atom => {
+            if !operator_position {
+                return Ok(sexp.clone());
+            }
+            let replacement = {
+                let atom = allocator.atom(sexp);
+                std::str::from_utf8(atom.as_ref())
+                    .ok()
+                    .and_then(|name| keyword_to_atom(OPERATORS_LATEST_VERSION).get(name))
+                    .cloned()
+            };
+            replacement.map_or_else(
+                || Ok(sexp.clone()),
+                |value| allocator.new_atom(allocator.loc(sexp), &value),
+            )
+        }
+    }
+}
+
+fn assemble_com_program<A: ClassicAllocator>(
+    allocator: &mut A,
+    sexp: &A::NodePtr,
+) -> Result<A::NodePtr, ClError>
+where
+    A::NodePtr: Clone,
+{
+    match allocator.sexp(sexp) {
+        ASExp::Pair(program, extras) => {
+            let program = assemble_operator_heads(allocator, &program, true)?;
+            allocator.new_pair(allocator.loc(sexp), &program, &extras)
+        }
+        ASExp::Atom => Ok(sexp.clone()),
+    }
+}
+
 impl Dialect for CompilerOperatorsInternal {
     fn quote_kw(&self) -> u32 {
         1
@@ -446,7 +505,11 @@ impl Dialect for CompilerOperatorsInternal {
         // compiler doesn't itself run in a softfork.
         let extensions_to_clvmr_during_compile = self.get_operators_extension();
 
-        eprintln!("op {} for {}", disassemble(allocator, op, None), disassemble(allocator, sexp, None));
+        eprintln!(
+            "op {} for {}",
+            disassemble(allocator, op, None),
+            disassemble(allocator, sexp, None)
+        );
 
         match allocator.sexp(op) {
             SExp::Atom => {
@@ -458,10 +521,14 @@ impl Dialect for CompilerOperatorsInternal {
                 } else if opbuf == b"_write" {
                     self.write(allocator, sexp)
                 } else if opbuf == b"com" {
-                    if self.is_modern() {
-                        todo!();
-                    }
-                    let result = do_com_prog_for_dialect(self.get_runner(), allocator, &sexp)?;
+                    let assembled;
+                    let sexp = if self.is_modern() {
+                        assembled = assemble_com_program(allocator, &sexp)?;
+                        &assembled
+                    } else {
+                        &sexp
+                    };
+                    let result = do_com_prog_for_dialect(self.get_runner(), allocator, sexp)?;
                     Ok(Reduction(1, result))
                 } else if opbuf == b"opt" {
                     let result = do_optimize(self.get_runner(), allocator, &self.opt_memo, &sexp)?;
@@ -569,4 +636,67 @@ pub fn run_program_for_search_paths(
     ));
     ops.parent.set_runner(ops.parent.clone());
     ops
+}
+
+#[cfg(test)]
+mod tests {
+    use super::assemble_com_program;
+    use crate::classic::clvm_tools::stages::stage_2::abstraction::{
+        ASExp, BufCarrier, ClassicAllocator, SExpClassicAllocator,
+    };
+    use crate::compiler::sexp::{enlist, SExp};
+    use crate::compiler::srcloc::Srcloc;
+    use std::rc::Rc;
+
+    #[test]
+    fn modern_com_program_assembles_operator_heads_with_their_source_locations() {
+        let filename = Rc::new("*assemble-operator-test*".to_string());
+        let program_loc = Srcloc::new(filename.clone(), 1, 1);
+        let quote_loc = Srcloc::new(filename.clone(), 1, 2);
+        let argument_loc = Srcloc::new(filename.clone(), 1, 4);
+        let nested_loc = Srcloc::new(filename.clone(), 1, 6);
+        let nested_quote_loc = Srcloc::new(filename, 1, 7);
+
+        let nested = Rc::new(enlist(
+            nested_loc,
+            &[Rc::new(SExp::Atom(nested_quote_loc.clone(), b"q".to_vec()))],
+        ));
+        let program = Rc::new(enlist(
+            program_loc.clone(),
+            &[
+                Rc::new(SExp::Atom(quote_loc.clone(), b"q".to_vec())),
+                Rc::new(SExp::Atom(argument_loc.clone(), b"q".to_vec())),
+                nested,
+            ],
+        ));
+        let com_arguments = Rc::new(enlist(program_loc, &[program]));
+
+        let mut allocator = SExpClassicAllocator::new();
+        let com_arguments = allocator.from_sexp(com_arguments).unwrap();
+        let assembled = assemble_com_program(&mut allocator, &com_arguments).unwrap();
+
+        let ASExp::Pair(program, _) = allocator.sexp(&assembled) else {
+            panic!("com arguments must be a pair");
+        };
+        let ASExp::Pair(operator, arguments) = allocator.sexp(&program) else {
+            panic!("program must be a pair");
+        };
+        assert_eq!(allocator.atom(&operator).as_ref(), &[1]);
+        assert_eq!(allocator.loc(&operator), quote_loc);
+
+        let ASExp::Pair(argument, remaining) = allocator.sexp(&arguments) else {
+            panic!("program arguments must be a pair");
+        };
+        assert_eq!(allocator.atom(&argument).as_ref(), b"q");
+        assert_eq!(allocator.loc(&argument), argument_loc);
+
+        let ASExp::Pair(nested, _) = allocator.sexp(&remaining) else {
+            panic!("nested expression must be present");
+        };
+        let ASExp::Pair(nested_operator, _) = allocator.sexp(&nested) else {
+            panic!("nested expression must be a pair");
+        };
+        assert_eq!(allocator.atom(&nested_operator).as_ref(), &[1]);
+        assert_eq!(allocator.loc(&nested_operator), nested_quote_loc);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- assemble textual CLVM operator heads before modern `com` compilation
- preserve source locations on replaced operator atoms
- pass the assembled argument expression to `do_com_prog_for_dialect`
- test top-level and nested quote operators while leaving non-head atoms unchanged

## Testing
- `cargo test modern_com_program_assembles_operator_heads_with_their_source_locations`
- `cargo test tests::classic::stage_2`
- `cargo check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4bff21aa-906c-4114-877f-74e33a36614e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bff21aa-906c-4114-877f-74e33a36614e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

