### PR TITLE
Support modern call semantics in classic codegen

### DIFF
--- a/src/classic/clvm_tools/stages/stage_2/compile.rs
+++ b/src/classic/clvm_tools/stages/stage_2/compile.rs
@@ -448,7 +448,7 @@ where
     A::NodePtr: Clone,
 {
     let loc = allocator.loc(prog);
-    if a == b"@" {
+    if a == b"@" || a == b"@*env*" {
         return allocator.new_atom(loc, NodePath::new(None).as_path().data());
     }
 

--- a/src/classic/clvm_tools/stages/stage_2/compile.rs
+++ b/src/classic/clvm_tools/stages/stage_2/compile.rs
@@ -580,6 +580,73 @@ where
     Ok(None)
 }
 
+fn split_rest_tail<A: ClassicAllocator>(
+    allocator: &A,
+    args: &A::NodePtr,
+) -> Result<Option<(Vec<A::NodePtr>, Option<A::NodePtr>)>, ClError>
+where
+    A::NodePtr: Clone,
+{
+    let Some(mut args) = proper_list(allocator, args, true).map(|args| args.to_vec()) else {
+        return Ok(None);
+    };
+
+    let rest_index = args.iter().position(|arg| match allocator.sexp(arg) {
+        ASExp::Atom => allocator.atom(arg).as_ref() == b"&rest",
+        ASExp::Pair(_, _) => false,
+    });
+
+    let Some(rest_index) = rest_index else {
+        return Ok(Some((args, None)));
+    };
+
+    if rest_index + 2 != args.len() {
+        return Err(ClError(
+            allocator.loc(&args[rest_index]),
+            EvalErr::InternalError(
+                allocator.export(&args[rest_index]),
+                "&rest must be followed by exactly one tail expression".to_string(),
+            ),
+        ));
+    }
+
+    let tail = args.pop();
+    args.pop();
+    Ok(Some((args, tail)))
+}
+
+fn enlist_with_tail<A: ClassicAllocator>(
+    allocator: &mut A,
+    args: &[A::NodePtr],
+    tail: &A::NodePtr,
+) -> Result<A::NodePtr, ClError>
+where
+    A::NodePtr: Clone,
+{
+    let mut result = tail.clone();
+    for arg in args.iter().rev() {
+        result = allocator.new_pair(allocator.loc(arg), arg, &result)?;
+    }
+    Ok(result)
+}
+
+fn rest_argument_source<A: ClassicAllocator>(
+    allocator: &mut A,
+    args: &[A::NodePtr],
+    tail: &A::NodePtr,
+) -> Result<A::NodePtr, ClError>
+where
+    A::NodePtr: Clone,
+{
+    let mut result = tail.clone();
+    for arg in args.iter().rev() {
+        let loc = allocator.loc(arg);
+        let cons = allocator.new_atom(loc.clone(), b"c")?;
+        result = enlist(allocator, &[cons, arg.clone(), result])?;
+    }
+    Ok(result)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn compile_application<A: ClassicAllocator>(
     allocator: &mut A,
@@ -614,8 +681,8 @@ where
         return allocator.new_pair(rest_loc, operator, rest);
     }
 
-    match proper_list(allocator, rest, true) {
-        Some(prog_args) => {
+    match split_rest_tail(allocator, rest)? {
+        Some((prog_args, tail_arg)) => {
             let mut new_args = map_m(allocator, &mut prog_args.iter(), &|allocator, arg| {
                 do_com_prog(
                     allocator,
@@ -627,8 +694,19 @@ where
                 )
             })?;
 
+            let compiled_tail = match &tail_arg {
+                Some(tail) => do_com_prog(
+                    allocator,
+                    544,
+                    tail,
+                    macro_lookup,
+                    symbol_table,
+                    run_program.clone(),
+                )?,
+                None => allocator.import(allocator.loc(rest), NodePtr::NIL)?,
+            };
             compiled_args.append(&mut new_args);
-            let r = enlist(allocator, &compiled_args)?;
+            let r = enlist_with_tail(allocator, &compiled_args, &compiled_tail)?;
 
             if PASS_THROUGH_OPERATORS.contains(opbuf) || (!opbuf.is_empty() && opbuf[0] == b'_') {
                 Ok(r)
@@ -636,39 +714,34 @@ where
                 find_symbol_match(allocator, opbuf, &r, symbol_table).and_then(|x| match x {
                     Some(SymbolResult::Direct(v)) => Ok(v),
                     Some(SymbolResult::Matched(_symbol, value)) => {
-                        match proper_list(allocator, rest, true) {
-                            Some(proglist) => {
-                                let loc = allocator.loc(&value);
-                                let apply_atom = allocator.new_atom(loc.clone(), &[2])?;
-                                let list_atom =
-                                    allocator.new_atom(loc.clone(), "list".as_bytes())?;
-                                let cons_atom = allocator.new_atom(loc.clone(), &[4])?;
-                                let com_atom = allocator.new_atom(loc.clone(), "com".as_bytes())?;
-                                let opt_atom = allocator.new_atom(loc.clone(), "opt".as_bytes())?;
-                                let top_atom = allocator
-                                    .new_atom(loc.clone(), NodePath::new(None).as_path().data())?;
-                                let left_atom = allocator.new_atom(
-                                    loc.clone(),
-                                    NodePath::new(None).first().as_path().data(),
-                                )?;
-                                let enlisted = enlist(allocator, &proglist)?;
-                                let list_application =
-                                    allocator.new_pair(loc, &list_atom, &enlisted)?;
-                                let quoted_list = quote(allocator, &list_application)?;
-                                let quoted_macros = quote(allocator, macro_lookup)?;
-                                let quoted_symbols = quote(allocator, symbol_table)?;
-                                let compiled = enlist(
-                                    allocator,
-                                    &[com_atom, quoted_list, quoted_macros, quoted_symbols],
-                                )?;
-                                let to_run = enlist(allocator, &[opt_atom, compiled])?;
-                                let new_args = evaluate(allocator, &to_run, &top_atom)?;
-                                let cons_enlisted =
-                                    enlist(allocator, &[cons_atom, left_atom, new_args])?;
-                                enlist(allocator, &[apply_atom, value, cons_enlisted])
+                        let loc = allocator.loc(&value);
+                        let apply_atom = allocator.new_atom(loc.clone(), &[2])?;
+                        let list_atom = allocator.new_atom(loc.clone(), "list".as_bytes())?;
+                        let cons_atom = allocator.new_atom(loc.clone(), &[4])?;
+                        let com_atom = allocator.new_atom(loc.clone(), "com".as_bytes())?;
+                        let opt_atom = allocator.new_atom(loc.clone(), "opt".as_bytes())?;
+                        let top_atom = allocator
+                            .new_atom(loc.clone(), NodePath::new(None).as_path().data())?;
+                        let left_atom = allocator
+                            .new_atom(loc.clone(), NodePath::new(None).first().as_path().data())?;
+                        let argument_source = match &tail_arg {
+                            Some(tail) => rest_argument_source(allocator, &prog_args, tail)?,
+                            None => {
+                                let enlisted = enlist(allocator, &prog_args)?;
+                                allocator.new_pair(loc, &list_atom, &enlisted)?
                             }
-                            None => error_result,
-                        }
+                        };
+                        let quoted_list = quote(allocator, &argument_source)?;
+                        let quoted_macros = quote(allocator, macro_lookup)?;
+                        let quoted_symbols = quote(allocator, symbol_table)?;
+                        let compiled = enlist(
+                            allocator,
+                            &[com_atom, quoted_list, quoted_macros, quoted_symbols],
+                        )?;
+                        let to_run = enlist(allocator, &[opt_atom, compiled])?;
+                        let new_args = evaluate(allocator, &to_run, &top_atom)?;
+                        let cons_enlisted = enlist(allocator, &[cons_atom, left_atom, new_args])?;
+                        enlist(allocator, &[apply_atom, value, cons_enlisted])
                     }
                     None => error_result,
                 })

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -257,6 +257,7 @@ fn unquote_args<A: ClassicAllocator>(
     code: &A::NodePtr,
     args: &[Vec<u8>],
     matches: &HashMap<Vec<u8>, A::NodePtr>,
+    inline_env: &A::NodePtr,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -265,6 +266,9 @@ where
         ASExp::Atom => {
             // Only code in scope.
             let code_atom = allocator.atom(code);
+            if code_atom.as_ref() == b"@*env*" {
+                return Ok(inline_env.clone());
+            }
             let matching_args = args
                 .iter()
                 .filter(|arg| *arg == code_atom.as_ref())
@@ -285,10 +289,85 @@ where
             Ok(code.clone())
         }
         ASExp::Pair(c1, c2) => {
-            let unquoted_c2 = unquote_args(allocator, &c2, args, matches)?;
-            let unquoted_c1 = unquote_args(allocator, &c1, args, matches)?;
+            let unquoted_c2 = unquote_args(allocator, &c2, args, matches, inline_env)?;
+            let unquoted_c1 = unquote_args(allocator, &c1, args, matches, inline_env)?;
             let loc = allocator.loc(&c1);
             allocator.new_pair(loc, &unquoted_c1, &unquoted_c2)
+        }
+    }
+}
+
+fn inline_argument_reference<A: ClassicAllocator>(
+    allocator: &mut A,
+    arg: &A::NodePtr,
+    matches: &HashMap<Vec<u8>, A::NodePtr>,
+) -> Result<A::NodePtr, ClError>
+where
+    A::NodePtr: Clone,
+{
+    let reference = match allocator.sexp(arg) {
+        ASExp::Atom => {
+            let name = allocator.atom(arg).as_ref().to_vec();
+            if let Some(selection) = matches.get(&name) {
+                return Ok(selection.clone());
+            }
+            arg.clone()
+        }
+        ASExp::Pair(first, rest) => {
+            let Some((capture, _)) = is_at_capture(allocator, &first, &rest) else {
+                return Err(ClError(
+                    allocator.loc(arg),
+                    EvalErr::InternalError(
+                        allocator.export(arg),
+                        "inline argument destructuring is missing its source capture".to_string(),
+                    ),
+                ));
+            };
+            capture
+        }
+    };
+
+    let loc = allocator.loc(&reference);
+    let unquote = allocator.new_atom(loc, b"unquote")?;
+    enlist(allocator, &[unquote, reference])
+}
+
+fn inline_environment<A: ClassicAllocator>(
+    allocator: &mut A,
+    args: &A::NodePtr,
+    matches: &HashMap<Vec<u8>, A::NodePtr>,
+) -> Result<A::NodePtr, ClError>
+where
+    A::NodePtr: Clone,
+{
+    let loc = allocator.loc(args);
+    let Some(args) = proper_list(allocator, args, true) else {
+        return Err(ClError(
+            loc,
+            EvalErr::InternalError(
+                allocator.export(args),
+                "@*env* does not yet support an inline function with a dotted argument list"
+                    .to_string(),
+            ),
+        ));
+    };
+
+    let cons = allocator.new_atom(loc.clone(), b"c")?;
+    let left_environment = allocator.new_atom(loc.clone(), &[2])?;
+    let mut right_environment = allocator.import(loc.clone(), NodePtr::NIL)?;
+    for arg in args.iter().rev() {
+        let argument = inline_argument_reference(allocator, arg, matches)?;
+        right_environment = enlist(allocator, &[cons.clone(), argument, right_environment])?;
+    }
+    enlist(allocator, &[cons, left_environment, right_environment])
+}
+
+fn contains_inline_environment<A: ClassicAllocator>(allocator: &A, code: &A::NodePtr) -> bool {
+    match allocator.sexp(code) {
+        ASExp::Atom => allocator.atom(code).as_ref() == b"@*env*",
+        ASExp::Pair(first, rest) => {
+            contains_inline_environment(allocator, &first)
+                || contains_inline_environment(allocator, &rest)
         }
     }
 }
@@ -339,7 +418,18 @@ where
         .map(|v| v.as_ref().to_vec())
         .collect::<Vec<Vec<u8>>>();
 
-    let unquoted_code = unquote_args(allocator, &code, &arg_name_list, &destructure_matches)?;
+    let inline_env = if contains_inline_environment(allocator, &code) {
+        inline_environment(allocator, &use_args, &destructure_matches)?
+    } else {
+        code.clone()
+    };
+    let unquoted_code = unquote_args(
+        allocator,
+        &code,
+        &arg_name_list,
+        &destructure_matches,
+        &inline_env,
+    )?;
 
     let loc = allocator.loc(&unquoted_code);
     let qq_atom = allocator.new_atom(loc, "qq".as_bytes())?;

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -341,21 +341,30 @@ where
     A::NodePtr: Clone,
 {
     let loc = allocator.loc(args);
-    let Some(args) = proper_list(allocator, args, true) else {
-        return Err(ClError(
-            loc,
-            EvalErr::InternalError(
-                allocator.export(args),
-                "@*env* does not yet support an inline function with a dotted argument list"
-                    .to_string(),
-            ),
-        ));
+    let argument_tree = match allocator.sexp(args) {
+        ASExp::Pair(first, rest) => is_at_capture(allocator, &first, &rest)
+            .map(|(_, destructure)| destructure)
+            .unwrap_or_else(|| args.clone()),
+        ASExp::Atom => args.clone(),
     };
 
     let cons = allocator.new_atom(loc.clone(), b"c")?;
     let left_environment = allocator.new_atom(loc.clone(), &[2])?;
-    let mut right_environment = allocator.import(loc.clone(), NodePtr::NIL)?;
-    for arg in args.iter().rev() {
+    let mut argument_references = Vec::new();
+    let mut remaining = argument_tree;
+    while let ASExp::Pair(first, rest) = allocator.sexp(&remaining) {
+        argument_references.push(first);
+        remaining = rest;
+    }
+
+    let mut right_environment = if allocator.is_nil(&remaining) {
+        allocator.import(loc.clone(), NodePtr::NIL)?
+    } else {
+        let tail = inline_argument_reference(allocator, &remaining, matches)?;
+        let enlist_args = allocator.new_atom(loc.clone(), b"__chia__enlist")?;
+        enlist(allocator, &[enlist_args, tail])?
+    };
+    for arg in argument_references.iter().rev() {
         let argument = inline_argument_reference(allocator, arg, matches)?;
         right_environment = enlist(allocator, &[cons.clone(), argument, right_environment])?;
     }

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -135,6 +135,29 @@ fn test_classic_codegen_function_call_with_rest_tail() {
 }
 
 #[test]
+fn test_classic_codegen_environment_pseudo_variable() {
+    let program = indoc! {"
+        (mod (X)
+          (include *standard-cl-26-classic*)
+          (defun regular (A B)
+            (r @*env*))
+          (defun-inline inlined (A B)
+            (r @*env*))
+          (list
+            (regular X (+ X 1))
+            (inlined (+ X 2) (+ X 3))))
+    "}
+    .to_string();
+
+    assert_eq!(
+        run_string(&program, &"(5)".to_string())
+            .unwrap()
+            .to_string(),
+        "((5 6) (7 8))"
+    );
+}
+
+#[test]
 fn test_classic_codegen_matches_modern_bls_program_result() {
     let modern =
         fs::read_to_string("resources/tests/bls/modern-bls-verify-signature.clsp").unwrap();

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -151,7 +151,7 @@ fn test_classic_codegen_environment_pseudo_variable() {
             (regular X (+ X 1))
             (inlined (+ X 2) (+ X 3))
             (destructured (list X (+ X 1)) (+ X 2))
-            (variadic (+ X 4) &rest (list (+ X 5) (+ X 6)))))
+            (variadic (+ X 4) (+ X 5) (+ X 6))))
     "}
     .to_string();
 

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -143,9 +143,15 @@ fn test_classic_codegen_environment_pseudo_variable() {
             (r @*env*))
           (defun-inline inlined (A B)
             (r @*env*))
+          (defun-inline destructured ((A B) C)
+            (r @*env*))
+          (defun-inline variadic (A . Rest)
+            (r @*env*))
           (list
             (regular X (+ X 1))
-            (inlined (+ X 2) (+ X 3))))
+            (inlined (+ X 2) (+ X 3))
+            (destructured (list X (+ X 1)) (+ X 2))
+            (variadic (+ X 4) (+ X 5) (+ X 6))))
     "}
     .to_string();
 
@@ -153,7 +159,7 @@ fn test_classic_codegen_environment_pseudo_variable() {
         run_string(&program, &"(5)".to_string())
             .unwrap()
             .to_string(),
-        "((5 6) (7 8))"
+        "((5 6) (7 8) ((5 6) 7) (9 10 11))"
     );
 }
 

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -151,7 +151,7 @@ fn test_classic_codegen_environment_pseudo_variable() {
             (regular X (+ X 1))
             (inlined (+ X 2) (+ X 3))
             (destructured (list X (+ X 1)) (+ X 2))
-            (variadic (+ X 4) (+ X 5) (+ X 6))))
+            (variadic (+ X 4) &rest (list (+ X 5) (+ X 6)))))
     "}
     .to_string();
 

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -116,6 +116,25 @@ fn test_modern_frontend_with_classic_codegen_semantics() {
 }
 
 #[test]
+fn test_classic_codegen_function_call_with_rest_tail() {
+    let program = indoc! {"
+        (mod (Xs)
+          (include *standard-cl-26-classic*)
+          (defun collect (A B C D)
+            (list A B C D))
+          (collect 5 &rest Xs))
+    "}
+    .to_string();
+
+    assert_eq!(
+        run_string(&program, &"((7 11 13))".to_string())
+            .unwrap()
+            .to_string(),
+        "(5 7 11 13)"
+    );
+}
+
+#[test]
 fn test_classic_codegen_matches_modern_bls_program_result() {
     let modern =
         fs::read_to_string("resources/tests/bls/modern-bls-verify-signature.clsp").unwrap();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- recognize `&rest` in classic function-call argument lists and compile its expression as the runtime tail
- recognize `@*env*` as the current environment in non-inline functions
- reify inline `@*env*` by consing the immutable left environment with evaluated inline arguments
- reconstruct proper, destructured, and variadic inline argument environments
- add classic-codegen execution coverage for the new semantics

## Testing
- `cargo test test_classic_codegen_environment_pseudo_variable`
- `cargo test test_classic_codegen_function_call_with_rest_tail`
- `cargo test tests::classic::stage_2` (17 passed)
- `cargo test tests::compiler::compiler` (140 passed)
- `cargo check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4bff21aa-906c-4114-877f-74e33a36614e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bff21aa-906c-4114-877f-74e33a36614e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

