### PR TITLE
Fix neoclassic let code generation equivalence

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -1575,7 +1575,7 @@ pub fn hoist_body_let_binding(
                 }));
             }
             let generated_defun = generate_let_defun(
-                opts,
+                opts.clone(),
                 letdata.loc.clone(),
                 None,
                 &defun_name,
@@ -1590,6 +1590,14 @@ pub fn hoist_body_let_binding(
             let pass_env = outer_context
                 .map(create_let_env_expression)
                 .unwrap_or_else(|| {
+                    // Modern codegen wraps the module arguments in its function
+                    // environment. Classic stage 2 exposes them directly.
+                    if opts.dialect().classic_codegen {
+                        return BodyForm::Value(SExp::Atom(
+                            letdata.loc.clone(),
+                            "@*env*".as_bytes().to_vec(),
+                        ));
+                    }
                     BodyForm::Call(
                         letdata.loc.clone(),
                         vec![

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -15,7 +15,7 @@ use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero};
 use crate::classic::clvm_tools::ir::r#type::NEW_BIT_CONSTANTS;
 use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::classic::clvm_tools::stages::stage_2::abstraction::{
-    ClassicAllocator, SExpClassicAllocator,
+    ASExp, BufCarrier, ClassicAllocator, SExpClassicAllocator,
 };
 use crate::classic::clvm_tools::stages::stage_2::defaults::default_macro_lookup;
 use crate::classic::clvm_tools::stages::stage_2::module::compile_mod;
@@ -216,6 +216,19 @@ fn classic_codegen(opts: Rc<dyn CompilerOpts>, program: CompileForm) -> Result<S
     .map_err(|e| CompileErr(e.0, e.1.to_string()))?;
     let optimized = optimize_sexp(&mut allocator, &generated, runner)
         .map_err(|e| CompileErr(e.0, e.1.to_string()))?;
+
+    // compile_mod produces a compiler program. Optimizing the primary module
+    // evaluates that program and quotes the resulting CLVM as constant data.
+    // Included modules still need the quote while they are being compiled.
+    if opts.module_phase().is_none() && program.loc.file.as_str() == opts.filename() {
+        if let ASExp::Pair(operator, compiled) = allocator.sexp(&optimized) {
+            if matches!(allocator.sexp(&operator), ASExp::Atom)
+                && allocator.atom(&operator).as_ref() == [1]
+            {
+                return Ok(compiled.sexp.as_ref().clone());
+            }
+        }
+    }
 
     Ok(optimized.sexp.as_ref().clone())
 }

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -2784,17 +2784,27 @@ fn test_equivalence_smoke_modern_neoclassic() {
 
   (let ((B (+ A 1))) (* B A))
   )
-    "}.to_string();
+    "}
+    .to_string();
 
-    let program_modern = program_neo.replace("cl-26-classic", "cl26").to_string();
+    let program_modern = program_neo.replace("cl-26-classic", "cl-26").to_string();
     let clvm_modern = do_basic_run(&vec!["run".to_string(), program_modern.to_string()]);
     let clvm_neo = do_basic_run(&vec!["run".to_string(), program_neo.to_string()]);
 
     for a in 0..12 {
         let brun_arg = format!("({a})");
-        let output_modern = do_basic_brun(&vec!["brun".to_string(), clvm_modern.to_string(), brun_arg.to_string()]);
+        let output_modern = do_basic_brun(&vec![
+            "brun".to_string(),
+            clvm_modern.to_string(),
+            brun_arg.to_string(),
+        ]);
         let b = a + 1;
-        assert_eq!(output_modern.trim(), (a * b).to_string());
+        let expected = if a == 0 {
+            "()".to_string()
+        } else {
+            (a * b).to_string()
+        };
+        assert_eq!(output_modern.trim(), expected);
 
         let output_neo = do_basic_brun(&vec!["brun".to_string(), clvm_neo.to_string(), brun_arg]);
         assert_eq!(output_neo.trim(), output_modern.trim());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- unwrap the primary classic stage-2 compiler result before returning executable CLVM
- pass the direct module environment to synthetic classic-codegen let helpers
- correct the modern dialect substitution and CLVM zero expectation in the equivalence smoke test

## Test plan
- `cargo test test_equivalence_smoke_modern_neoclassic -- --nocapture`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c716f7c-d8db-48cb-a4d6-013783c95ead?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c716f7c-d8db-48cb-a4d6-013783c95ead&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

